### PR TITLE
Style Loader: Update the dependency tree for `colors`

### DIFF
--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -74,7 +74,7 @@ _wp_admin_html_begin();
 <title><?php echo esc_html( $admin_title ); ?></title>
 <?php
 
-wp_enqueue_style( 'colors' );
+wp_enqueue_style( 'wp-admin' );
 wp_enqueue_script( 'utils' );
 wp_enqueue_script( 'svg-painter' );
 

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -522,7 +522,7 @@ function wp_iframe( $content_func, ...$args ) {
 	<title><?php bloginfo( 'name' ); ?> &rsaquo; <?php _e( 'Uploads' ); ?> &#8212; <?php _e( 'WordPress' ); ?></title>
 	<?php
 
-	wp_enqueue_style( 'colors' );
+	wp_enqueue_style( 'wp-admin' );
 	// Check callback name for 'media'.
 	if (
 		( is_array( $content_func ) && ! empty( $content_func[1] ) && 0 === strpos( (string) $content_func[1], 'media' ) ) ||

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2028,7 +2028,7 @@ function iframe_header( $title = '', $deprecated = false ) {
 	?>
 <title><?php bloginfo( 'name' ); ?> &rsaquo; <?php echo $title; ?> &#8212; <?php _e( 'WordPress' ); ?></title>
 	<?php
-	wp_enqueue_style( 'colors' );
+	wp_enqueue_style( 'wp-admin' );
 	?>
 <script type="text/javascript">
 addLoadEvent = function(func){if(typeof jQuery!=='undefined')jQuery(document).ready(func);else if(typeof wpOnload!=='function'){wpOnload=func;}else{var oldonload=wpOnload;wpOnload=function(){oldonload();func();}}};

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1449,14 +1449,14 @@ function wp_default_styles( $styles ) {
 	$styles->add( 'code-editor', "/wp-admin/css/code-editor$suffix.css", array( 'wp-codemirror' ) );
 	$styles->add( 'site-health', "/wp-admin/css/site-health$suffix.css" );
 
-	$styles->add( 'wp-admin', false, array( 'dashicons', 'common', 'forms', 'admin-menu', 'dashboard', 'list-tables', 'edit', 'revisions', 'media', 'themes', 'about', 'nav-menus', 'widgets', 'site-icon', 'l10n' ) );
+	$styles->add( 'wp-admin', false, array( 'colors', 'dashicons', 'common', 'forms', 'admin-menu', 'dashboard', 'list-tables', 'edit', 'revisions', 'media', 'themes', 'about', 'nav-menus', 'widgets', 'site-icon', 'l10n', 'buttons' ) );
 
 	$styles->add( 'login', "/wp-admin/css/login$suffix.css", array( 'dashicons', 'buttons', 'forms', 'l10n' ) );
 	$styles->add( 'install', "/wp-admin/css/install$suffix.css", array( 'dashicons', 'buttons', 'forms', 'l10n' ) );
 	$styles->add( 'wp-color-picker', "/wp-admin/css/color-picker$suffix.css" );
-	$styles->add( 'customize-controls', "/wp-admin/css/customize-controls$suffix.css", array( 'wp-admin', 'colors', 'imgareaselect' ) );
-	$styles->add( 'customize-widgets', "/wp-admin/css/customize-widgets$suffix.css", array( 'wp-admin', 'colors' ) );
-	$styles->add( 'customize-nav-menus', "/wp-admin/css/customize-nav-menus$suffix.css", array( 'wp-admin', 'colors' ) );
+	$styles->add( 'customize-controls', "/wp-admin/css/customize-controls$suffix.css", array( 'wp-admin', 'imgareaselect' ) );
+	$styles->add( 'customize-widgets', "/wp-admin/css/customize-widgets$suffix.css", array( 'wp-admin' ) );
+	$styles->add( 'customize-nav-menus', "/wp-admin/css/customize-nav-menus$suffix.css", array( 'wp-admin' ) );
 
 	// Common dependencies.
 	$styles->add( 'buttons', "/wp-includes/css/buttons$suffix.css" );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1427,7 +1427,7 @@ function wp_default_styles( $styles ) {
 	}
 
 	// Register a stylesheet for the selected admin color scheme.
-	$styles->add( 'colors', '/wp-includes/css/custom-properties.css', array( 'wp-admin', 'buttons' ) );
+	$styles->add( 'colors', '/wp-includes/css/custom-properties.css' );
 
 	$suffix = SCRIPT_DEBUG ? '' : '.min';
 

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1451,8 +1451,8 @@ function wp_default_styles( $styles ) {
 
 	$styles->add( 'wp-admin', false, array( 'colors', 'dashicons', 'common', 'forms', 'admin-menu', 'dashboard', 'list-tables', 'edit', 'revisions', 'media', 'themes', 'about', 'nav-menus', 'widgets', 'site-icon', 'l10n', 'buttons' ) );
 
-	$styles->add( 'login', "/wp-admin/css/login$suffix.css", array( 'dashicons', 'buttons', 'forms', 'l10n' ) );
-	$styles->add( 'install', "/wp-admin/css/install$suffix.css", array( 'dashicons', 'buttons', 'forms', 'l10n' ) );
+	$styles->add( 'login', "/wp-admin/css/login$suffix.css", array( 'colors', 'dashicons', 'buttons', 'forms', 'l10n' ) );
+	$styles->add( 'install', "/wp-admin/css/install$suffix.css", array( 'colors', 'dashicons', 'buttons', 'forms', 'l10n' ) );
 	$styles->add( 'wp-color-picker', "/wp-admin/css/color-picker$suffix.css" );
 	$styles->add( 'customize-controls', "/wp-admin/css/customize-controls$suffix.css", array( 'wp-admin', 'imgareaselect' ) );
 	$styles->add( 'customize-widgets', "/wp-admin/css/customize-widgets$suffix.css", array( 'wp-admin' ) );


### PR DESCRIPTION
Currently, when the `colors` stylesheet is registered, it says that `wp-admin` and `buttons` are dependencies - this ensures that the wp-admin & buttons files are all loaded before colors, so that the color schemes can override them. That's not necessary for the custom properties, and can lead to unexpected behavior if `colors` is declared a dependency of, for example `login`.

This change removes the dependencies from `colors`, and sets `colors` and `buttons` as a dependency of `wp-admin` – flipping the current behavior. Now we enqueue `wp-admin` as the entrypoint for styles in wp-admin, and that loads the collection of styles.

This also means we can add `colors` as a dependency to `login` & `install`, which are currently missing some button colors 😶 

Props @0aveRyan for the idea to update the dependencies