### PR TITLE
PR#12 -- Add CSS Custom Properties for `color-picker.css`

### DIFF
--- a/src/wp-admin/css/color-picker.css
+++ b/src/wp-admin/css/color-picker.css
@@ -17,10 +17,10 @@
 }
 
 .wp-color-result-text {
-	background: #f6f7f7;
+	background: var(--wp-admin--color-result-text--background);
 	border-radius: 0 2px 2px 0;
 	border-left: 1px solid #c3c4c7;
-	color: #50575e;
+	color: var(--wp-admin--color-result-text--color);
 	display: block;
 	line-height: 2.54545455; /* 28px */
 	padding: 0 6px;
@@ -29,15 +29,15 @@
 
 .wp-color-result:hover,
 .wp-color-result:focus {
-	background: #f6f7f7;
-	border-color: #8c8f94;
-	color: #1d2327;
+	background: var(--wp-admin--color-result--background--hover);
+	border-color: var(--wp-admin--color-result--border-color--hover);
+	color: var(--wp-admin--color-result--color--hover);
 }
 
 .wp-color-result:hover:after,
 .wp-color-result:focus:after {
-	color: #1d2327;
-	border-color: #a7aaad;
+	color: var(--wp-admin--color-result--color--hover-after);
+	border-color: var(--wp-admin--color-result--border-color--hover-after);
 	border-left: 1px solid #8c8f94;
 }
 
@@ -46,7 +46,7 @@
 }
 
 .wp-color-result:focus {
-	border-color: #4f94d4;
+	border-color: var(--wp-admin--color-result--border-color--focus);
 	box-shadow: 0 0 3px rgba(34, 113, 177, 0.8);
 }
 
@@ -81,12 +81,12 @@
 }
 
 .wp-picker-container .iris-square-slider .ui-slider-handle:focus {
-	background-color: #50575e
+	background-color: var(--wp-admin--ui-slider-handle--background-color--focus);
 }
 
 .wp-picker-container .iris-picker {
 	border-radius: 0;
-	border-color: #dcdcde;
+	border-color: var(--wp-admin--iris-picker--border-color);
 	margin-top: 6px;
 }
 
@@ -102,34 +102,34 @@
 }
 
 .wp-color-picker::-webkit-input-placeholder {
-	color: #646970;
+	color: var(--wp-admin--color-picker--color--webkit-input-placeholder);
 }
 
 .wp-color-picker::-moz-placeholder {
-	color: #646970;
+	color: var(--wp-admin--color-picker--color--moz-placeholder);
 	opacity: 1;
 }
 
 .wp-color-picker:-ms-input-placeholder {
-	color: #646970;
+	color: var(--wp-admin--color-picker--color--ms-input-placeholder);
 }
 
 .wp-picker-container input[type="text"].iris-error {
-	background-color: #fcf0f1;
-	border-color: #d63638;
-	color: #000;
+	background-color: var(--wp-admin--picker-container-iris-container--background-color);
+	border-color: var(--wp-admin--picker-container-iris-container--border-color);
+	color: var(--wp-admin--picker-container-iris-container--color);
 }
 
 .iris-picker .ui-square-handle:focus,
 .iris-picker .iris-strip .ui-slider-handle:focus {
-	border-color: #3582c4;
+	border-color: var(--wp-admin--ui-square-handle--border-color--focus);
 	border-style: solid;
-	box-shadow: 0 0 0 1px #3582c4;
+	box-shadow: 0 0 0 1px var(--wp-admin--ui-square-handle--border-color--focus);
 	outline: 2px solid transparent;
 }
 
 .iris-picker .iris-palette:focus {
-	box-shadow: 0 0 0 2px #3582c4;
+	box-shadow: 0 0 0 2px var(--wp-admin--iris-pallete--box-shadow--focus);
 }
 
 @media screen and (max-width: 782px) {

--- a/src/wp-includes/css/custom-properties.css
+++ b/src/wp-includes/css/custom-properties.css
@@ -45,6 +45,31 @@ body {
 
 	--wp-admin--button--text: var(--wp-admin--button-primary);
 	--wp-admin--button-primary--text: var(--wp-admin--button);
+	
+	--wp-admin--color-result--background--hover: #f6f7f7;
+	--wp-admin--color-result--border-color--hover: #8c8f94;
+	--wp-admin--color-result--color--hover: #1d2327;
+
+	--wp-admin--color-result--color--hover-after: #1d2327;
+	--wp-admin--color-result--border-color--hover-after: #a7aaad;
+	--wp-admin--color-result--border-color--focus: #4f94d4;
+
+	--wp-admin--color-result-text--background: #f6f7f7;
+	--wp-admin--color-result-text--color: #50575e;
+
+	--wp-admin--color-picker--color--webkit-input-placeholder: #646970;
+	--wp-admin--color-picker--color--moz-placeholder: #646970;
+	--wp-admin--color-picker--color--ms-input-placeholder: #646970;
+
+	--wp-admin--iris-pallete--box-shadow--focus: #3582c4;
+	--wp-admin--iris-picker--border-color: #dcdcde;
+
+	--wp-admin--picker-container-iris-container--background-color: #fcf0f1;
+	--wp-admin--picker-container-iris-container--border-color: #d63638;
+	--wp-admin--picker-container-iris-container--color: #000;
+
+	--wp-admin--ui-slider-handle--background-color--focus: #50575e;
+	--wp-admin--ui-square-handle--border-color--focus: #3582c4;
 
 	--wp-admin--input--color: #2c3338;
 	--wp-admin--input--color--placeholder: #646970;


### PR DESCRIPTION
## Add CSS Custom Properties for `src/wp-admin/css/color-picker.css`

The following files for WordPress Core were updated: 

- `wordpress-develop/src/wp-admin/css/color-picker.css`; and 
- `wordpress-develop/src/wp-includes/css/custom-properties.css`.

The following CSS properties were modified in`color-picker.css`: 

- `background`,
- `border-color`,
- `box-shadow`, and 
- `color`,

**Note:** The value of `box-shadow` on Line 50 of `css-picker.css` was _not changed_ from `rgba` to a custom property. I await a response as to whether `rgba` values should be converted to a custom property. 

Trac ticket: [#49930, "Replace wp-admin color schemes with CSS custom properties". ](https://core.trac.wordpress.org/ticket/49930#no1)
