### PR TITLE
PR #21 -- Add CSS custom properties for `customize-controls.css`

### DIFF
--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -21,7 +21,8 @@ body {
 }
 
 #customize-controls #customize-notifications-area .notice.notification-overlay.notification-changeset-locked {
-	background-color: rgba(0, 0, 0, 0.7);
+	/*background-color: rgba(0, 0, 0, 0.7);*/
+	background-color: var(--wp-admin--background-color);
 	padding: 25px;
 }
 
@@ -33,7 +34,8 @@ body {
 	width: auto;
 	padding: 25px 25px 25px 109px;
 	position: relative;
-	background: #fff;
+	/*background: #fff;*/
+	background: var(--wp-admin--customize-changeset-locked-message--background);
 	box-shadow: 0 3px 6px rgba(0, 0, 0, 0.3);
 	line-height: 1.5;
 	overflow-y: auto;
@@ -61,7 +63,8 @@ body {
 }
 
 #customize-controls .description {
-	color: #50575e;
+	/*color: #50575e;*/
+	color: var(--wp-admin--color);
 }
 
 #customize-save-button-wrapper {
@@ -98,7 +101,8 @@ body:not(.ready) #customize-save-button-wrapper .save {
 	width: 100%;
 	margin: 0;
 	z-index: -1;
-	background: #f0f0f1;
+	/*background: #f0f0f1;*/
+	background: var(--wp-admin--customize-sidebar-outer-content--background);
 	transition: left .18s;
 	border-right: 1px solid #dcdcde;
 	border-left: 1px solid #dcdcde;
@@ -188,7 +192,8 @@ body.trashing #publish-settings {
 }
 
 .outer-section-open #customize-controls .wp-full-overlay-sidebar-content {
-	background: #f0f0f1;
+	/*background: #f0f0f1;*/
+	background: var(--wp-admin--full-overlay-sidebar-content--background);
 }
 
 #customize-controls .customize-info {
@@ -199,7 +204,8 @@ body.trashing #publish-settings {
 
 #customize-control-changeset_status .customize-inside-control-row,
 #customize-control-changeset_preview_link input {
-	background-color: #fff;
+	/*background-color: #fff;*/
+	background-color: var(--wp-admin--customize-inside-control-row--background-color);
 	border-bottom: 1px solid #dcdcde;
 	box-sizing: content-box;
 	width: 100%;
@@ -226,7 +232,8 @@ body.trashing #publish-settings {
 }
 
 #customize-controls .date-input:invalid {
-	border-color: #d63638;
+	/*border-color: #d63638;*/
+	border-color: var(--wp-admin--border-color);
 }
 
 #customize-control-changeset_status .customize-inside-control-row {
@@ -268,7 +275,8 @@ body.trashing #publish-settings {
 	content: "";
 	height: 28px;
 	position: absolute;
-	background: #fff;
+	/*background: #fff;*/
+	background: var(--wp-admin--background);
 	top: -1px;
 }
 
@@ -290,7 +298,8 @@ body.trashing #publish-settings {
 	border-left: none;
 	border-right: none;
 	text-indent: -999px;
-	color: #fff;
+	/*color: #fff;*/
+	color: var(--wp-admin--color);
 	/* Only necessary for IE11 */
 	min-height: 40px;
 }
@@ -315,7 +324,8 @@ body.trashing #publish-settings {
 #customize-control-changeset_preview_link a.disabled:active,
 #customize-control-changeset_preview_link a.disabled:focus,
 #customize-control-changeset_preview_link a.disabled:visited {
-	color: #000;
+	/*color: #000;*/
+	color: var(--wp-admin--color);
 	opacity: 0.4;
 	cursor: default;
 	outline: none;
@@ -376,7 +386,8 @@ body.trashing #publish-settings {
 	width: 100%;
 	margin-left: -12px;
 	padding: 12px;
-	background: #fff;
+	/*background: #fff;*/
+	background: var(--wp-admin--background);
 	border-bottom: 1px solid #dcdcde;
 	margin-bottom: 0;
 }
@@ -408,8 +419,10 @@ body.trashing #publish-settings {
 }
 
 #customize-controls .customize-info .accordion-section-title {
-	background: #fff;
-	color: #50575e;
+	/*background: #fff;*/
+	background: var(--wp-admin--background);
+	/*color: #50575e;*/
+	color: var(--wp-admin--color);
 	border-left: none;
 	border-right: none;
 	border-bottom: none;
@@ -419,7 +432,8 @@ body.trashing #publish-settings {
 #customize-controls .customize-info.open .accordion-section-title:after,
 #customize-controls .customize-info .accordion-section-title:hover:after,
 #customize-controls .customize-info .accordion-section-title:focus:after {
-	color: #2c3338;
+	/*color: #2c3338;*/
+	color: var(--wp-admin--color);
 }
 
 #customize-controls .customize-info .accordion-section-title:after {
@@ -461,8 +475,10 @@ body.trashing #publish-settings {
 	cursor: pointer;
 	box-shadow: none;
 	-webkit-appearance: none;
-	background: transparent;
-	color: #50575e;
+	/*background: transparent;*/
+	background: var(--wp-admin--background);
+	/*color: #50575e;*/
+	color: var(--wp-admin--color);
 	border: none;
 }
 
@@ -475,16 +491,19 @@ body.trashing #publish-settings {
 #customize-controls .customize-info.open .customize-help-toggle,
 #customize-controls .customize-info .customize-help-toggle:focus,
 #customize-controls .customize-info .customize-help-toggle:hover {
-	color: #2271b1;
+	/*color: #2271b1;*/
+	color: var(--wp-admin--color);
 }
 
 #customize-controls .customize-info .customize-panel-description,
 #customize-controls .customize-info .customize-section-description,
 #customize-outer-theme-controls .customize-info .customize-section-description,
 #customize-controls .no-widget-areas-rendered-notice {
-	color: #50575e;
+	/*color: #50575e;*/
+	color: var(--wp-admin--color);
 	display: none;
-	background: #fff;
+	/*background: #fff;*/
+	background: var(--wp-admin--background);
 	padding: 12px 15px;
 	border-top: 1px solid #dcdcde;
 }
@@ -527,8 +546,10 @@ body.trashing #publish-settings {
 
 #customize-theme-controls .accordion-section-title,
 #customize-outer-theme-controls .accordion-section-title {
-	color: #50575e;
-	background-color: #fff;
+	/*color: #50575e;*/
+	color: var(--wp-admin--color);
+	/*background-color: #fff;*/
+	background-color: var(--wp-admin--background-color);
 	border-bottom: 1px solid #dcdcde;
 	border-left: 4px solid #fff;
 	transition:
@@ -538,29 +559,36 @@ body.trashing #publish-settings {
 }
 
 #customize-controls #customize-theme-controls .customize-themes-panel .accordion-section-title {
-	color: #50575e;
-	background-color: #fff;
+	/*color: #50575e;*/
+	color: var(--wp-admin--color);
+	/*background-color: #fff;*/
+	background-color: var(--wp-admin--background-color);
 	border-left: 4px solid #fff;
 }
 
 #customize-theme-controls .accordion-section-title:after,
 #customize-outer-theme-controls .accordion-section-title:after {
 	content: "\f345";
-	color: #a7aaad;
+	/*color: #a7aaad;*/
+	color: var(--wp-admin--color);
 }
 
 #customize-theme-controls .accordion-section-content,
 #customize-outer-theme-controls .accordion-section-content {
-	color: #50575e;
-	background: transparent;
+	/*color: #50575e;*/
+	color: var(--wp-admin--color);
+	/*background: transparent;*/
+	background: var(--wp-admin--background);
 }
 
 #customize-controls .control-section:hover > .accordion-section-title,
 #customize-controls .control-section .accordion-section-title:hover,
 #customize-controls .control-section.open .accordion-section-title,
 #customize-controls .control-section .accordion-section-title:focus {
-	color: #2271b1;
-	background: #f6f7f7;
+	/*color: #2271b1;*/
+	color: var(--wp-admin--color);
+	/*background: #f6f7f7;*/
+	background: var(--wp-admin--background);
 	border-left-color: #2271b1;
 }
 
@@ -572,7 +600,8 @@ body.trashing #publish-settings {
 .js .control-section .accordion-section-title:hover,
 .js .control-section.open .accordion-section-title,
 .js .control-section .accordion-section-title:focus {
-	background: #f6f7f7;
+	/*background: #f6f7f7;*/
+	background: var(--wp-admin--background);
 }
 
 #customize-theme-controls .control-section:hover > .accordion-section-title:after,
@@ -583,7 +612,8 @@ body.trashing #publish-settings {
 #customize-outer-theme-controls .control-section .accordion-section-title:hover:after,
 #customize-outer-theme-controls .control-section.open .accordion-section-title:after,
 #customize-outer-theme-controls .control-section .accordion-section-title:focus:after {
-	color: #2271b1;
+	/*color: #2271b1;*/
+	color: var(--wp-admin--color);
 }
 
 #customize-theme-controls .control-section.open {
@@ -718,7 +748,8 @@ body.trashing #publish-settings {
 .customize-section-title {
 	margin: -12px -12px 0 -12px;
 	border-bottom: 1px solid #dcdcde;
-	background: #fff;
+	/*background: #fff;*/
+	background: var(--wp-admin--background);
 }
 
 div.customize-section-description {
@@ -751,7 +782,8 @@ h3.customize-section-title {
 	padding: 10px 10px 12px 14px;
 	margin: 0;
 	line-height: 21px;
-	color: #50575e;
+	/*color: #50575e;*/
+	color: var(--wp-admin--color);
 }
 
 .accordion-sub-container.control-panel-content {
@@ -777,11 +809,13 @@ h3.customize-section-title {
 	width: 45px;
 	height: 41px;
 	padding: 0 2px 0 0;
-	background: #f0f0f1;
+	/*background: #f0f0f1;*/
+	background: var(--wp-admin--background);
 	border: none;
 	border-top: 4px solid #f0f0f1;
 	border-right: 1px solid #dcdcde;
-	color: #3c434a;
+	/*color: #3c434a;*/
+	color: var(--wp-admin--color);
 	text-align: left;
 	cursor: pointer;
 	transition:
@@ -799,7 +833,8 @@ h3.customize-section-title {
 	height: 71px;
 	padding: 0 24px 0 0;
 	margin: 0;
-	background: #fff;
+	/*background: #fff;*/
+	background: var(--wp-admin--background);
 	border: none;
 	border-right: 1px solid #dcdcde;
 	border-left: 4px solid #fff;
@@ -830,8 +865,10 @@ h3.customize-section-title {
 
 #customize-controls .panel-meta.customize-info .accordion-section-title:hover,
 #customize-controls .cannot-expand:hover .accordion-section-title {
-	background: #fff;
-	color: #50575e;
+	/*background: #fff;*/
+	background: var(--wp-admin--background);
+	/*color: #50575e;*/
+	color: var(--wp-admin--color);
 	border-left-color: #fff;
 }
 
@@ -839,8 +876,10 @@ h3.customize-section-title {
 .customize-controls-close:hover,
 .customize-controls-preview-toggle:focus,
 .customize-controls-preview-toggle:hover {
-	background: #fff;
-	color: #2271b1;
+	/*background: #fff;*/
+	background: var(--wp-admin--background);
+	/*color: #2271b1;*/
+	color: var(--wp-admin--color);
 	border-top-color: #2271b1;
 	box-shadow: none;
 	/* Only visible in Windows High Contrast mode */
@@ -857,8 +896,10 @@ h3.customize-section-title {
 .customize-panel-back:focus,
 .customize-section-back:hover,
 .customize-section-back:focus {
-	color: #2271b1;
-	background: #f6f7f7;
+	/*color: #2271b1;*/
+	color: var(--wp-admin--color);
+	/*background: #f6f7f7;*/
+	background: var(--wp-admin--background);
 	border-left-color: #2271b1;
 	box-shadow: none;
 	/* Only visible in Windows High Contrast mode */
@@ -883,7 +924,8 @@ h3.customize-section-title {
 }
 
 .wp-full-overlay-sidebar .wp-full-overlay-header {
-	background-color: #f0f0f1;
+	/*background-color: #f0f0f1;*/
+	background-color: var(--wp-admin--background-color);
 	transition: padding ease-in-out .18s;
 }
 
@@ -1062,7 +1104,8 @@ p.customize-section-description {
 	position: absolute;
 	bottom: 0;
 	z-index: 10;
-	background: #f0f0f1;
+	/*background: #f0f0f1;*/
+	background: var(--wp-admin--background);
 	display: flex;
 }
 
@@ -1103,7 +1146,8 @@ p.customize-section-description {
 }
 
 .wp-full-overlay-sidebar {
-	background: #f0f0f1;
+	/*background: #f0f0f1;*/
+	background: var(--wp-admin--background);
 	border-right: 1px solid #dcdcde;
 }
 
@@ -1219,7 +1263,8 @@ p.customize-section-description {
 /* Note: Styles for this are also defined in themes.css */
 #customize-controls #customize-notifications-area .notice.notification-overlay .notification-message {
 	clear: both;
-	color: #1d2327;
+	/*color: #1d2327;*/
+	color: var(--wp-admin--color);
 	font-size: 18px;
 	font-style: normal;
 	margin: 0;
@@ -1275,7 +1320,8 @@ p.customize-section-description {
 	bottom: 0;
 	right: 0;
 	width: 20px;
-	background: #f0f0f1;
+	/*background: #f0f0f1;*/
+	background: var(--wp-admin--background);
 }
 
 .customize-control .dropdown-arrow:after {
@@ -1290,12 +1336,15 @@ p.customize-section-description {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	text-decoration: none !important;
-	color: #2c3338;
+	/*color: #2c3338;*/
+	color: var(--wp-admin--color);
 }
 
 .customize-control .dropdown-status {
-	color: #2c3338;
-	background: #f0f0f1;
+	/*color: #2c3338;*/
+	color: var(--wp-admin--color);
+	/*background: #f0f0f1;*/
+	background: var(--wp-admin--background);
 	display: none;
 	max-width: 112px;
 }
@@ -1306,7 +1355,8 @@ p.customize-section-description {
 }
 
 .customize-control-color .dropdown .dropdown-content {
-	background-color: #50575e;
+	/*background-color: #50575e;*/
+	background-color: var(--wp-admin--background-color);
 	border: 1px solid rgba(0, 0, 0, 0.15);
 }
 
@@ -1343,9 +1393,11 @@ p.customize-section-description {
 	width: 100%;
 	padding: 0;
 	margin: 0;
-	background: none;
+	/*background: none;*/
+	background: var(--wp-admin--background);
 	border: none;
-	color: inherit;
+	/*color: inherit;*/
+	color: var(--wp-admin--color);
 	cursor: pointer;
 }
 
@@ -1383,16 +1435,20 @@ p.customize-section-description {
 
 .customize-control .attachment-media-view .button-add-media {
 	cursor: pointer;
-	background-color: #f0f0f1;
-	color: #2c3338;
+	/*background-color: #f0f0f1;*/
+	background-color: var(--wp-admin--background-color);
+	/*color: #2c3338;*/
+	color: var(--wp-admin--color);
 }
 
 .customize-control .attachment-media-view .button-add-media:hover {
-	background-color: #fff;
+	/*background-color: #fff;*/
+	background-color: var(--wp-admin--background-color);
 }
 
 .customize-control .attachment-media-view .button-add-media:focus {
-	background-color: #fff;
+	/*background-color: #fff;*/
+	background-color: var(--wp-admin--background-color);
 	border-color: #3582c4;
 	border-style: solid;
 	box-shadow: 0 0 0 1px #3582c4;
@@ -1404,7 +1460,8 @@ p.customize-section-description {
 	display: none;
 	position: absolute;
 	width: 100%;
-	color: #50575e;
+	/*color: #50575e;*/
+	color: var(--wp-admin--color);
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow: hidden;
@@ -1460,8 +1517,10 @@ p.customize-section-description {
 
 .customize-control-header .uploaded .header-view .close {
 	font-size: 20px;
-	color: #fff;
-	background: #50575e;
+	/*color: #fff;*/
+	color: var(--wp-admin--color);
+	/*background: #50575e;*/
+	background: var(--wp-admin--background);
 	background: rgba(0, 0, 0, 0.5);
 	position: absolute;
 	top: 10px;
@@ -1658,8 +1717,10 @@ p.customize-section-description {
 #customize-theme-controls .control-panel-themes > .accordion-section-title:hover, /* Not a focusable element. */
 #customize-theme-controls .control-panel-themes > .accordion-section-title {
 	cursor: default;
-	background: #fff;
-	color: #50575e;
+	/*background: #fff;*/
+	background: var(--wp-admin--background);
+	/*color: #50575e;*/
+	color: var(--wp-admin--color);
 	border-top: 1px solid #dcdcde;
 	border-bottom: 1px solid #dcdcde;
 	border-left: none;
@@ -1719,7 +1780,8 @@ p.customize-section-description {
 	overflow-y: scroll;
 	width: calc(100% - 300px);
 	height: calc(100% - 96px);
-	background: #f0f0f1;
+	/*background: #f0f0f1;*/
+	background: var(--wp-admin--background);
 	z-index: 20;
 }
 
@@ -1756,7 +1818,8 @@ p.customize-section-description {
 }
 
 .wp-full-overlay.in-themes-panel {
-	background: #f0f0f1; /* Prevents a black flash when fading in the panel */
+	/*background: #f0f0f1; !* Prevents a black flash when fading in the panel *!*/
+	background: var(--wp-admin--background);
 }
 
 .in-themes-panel #customize-save-button-wrapper,
@@ -1794,8 +1857,10 @@ p.customize-section-description {
 }
 
 .themes-filter-bar .feature-filter-toggle.open {
-	background: #f0f0f1;
+	/*background: #f0f0f1;*/
+	background: var(--wp-admin--background);
 	border-color: #8c8f94;
+	border-color: var(--wp-admin--border-color);
 	box-shadow: inset 0 2px 5px -3px rgba(0, 0, 0, 0.5);
 }
 
@@ -1812,7 +1877,8 @@ p.customize-section-description {
 	padding: 25px 0 25px 25px;
 	border-top: 0;
 	margin: 0;
-	background: #f0f0f1;
+	/*background: #f0f0f1;*/
+	background: var(--wp-admin--background);
 	border-bottom: 1px solid #dcdcde;
 }
 
@@ -1852,7 +1918,8 @@ p.customize-section-description {
 
 .control-panel-themes .filter-themes-count .themes-displayed {
 	font-weight: 600;
-	color: #50575e;
+	/*color: #50575e;*/
+	color: var(--wp-admin--color);
 }
 
 .customize-themes-notifications {
@@ -1877,12 +1944,14 @@ p.customize-section-description {
 	margin: 15px 0 0 0;
 	line-height: 16px;
 	border-bottom: 1px solid #dcdcde;
-	color: #50575e;
+	/*color: #50575e;*/
+	color: var(--wp-admin--color);
 }
 
 .control-panel-themes .customize-themes-section-title {
 	width: 100%;
-	background: #fff;
+	/*background: #fff;*/
+	background: var(--wp-admin--background);
 	box-shadow: none;
 	outline: none;
 	border-top: none;
@@ -1895,7 +1964,8 @@ p.customize-section-description {
 	text-align: left;
 	font-size: 14px;
 	font-weight: 600;
-	color: #50575e;
+	/*color: #50575e;*/
+	color: var(--wp-admin--color);
 	text-shadow: none;
 }
 
@@ -1911,8 +1981,10 @@ p.customize-section-description {
 .control-panel-themes .customize-themes-section-title:focus,
 .control-panel-themes .customize-themes-section-title:hover {
 	border-left-color: #2271b1;
-	color: #2271b1;
-	background: #f6f7f7;
+	/*color: #2271b1;*/
+	color: var(--wp-admin--color);
+	/*background: #f6f7f7;*/
+	background: var(--wp-admin--background);
 }
 
 .customize-themes-section-title:not(.selected):after {
@@ -1925,7 +1997,8 @@ p.customize-section-description {
 	height: 18px;
 	border-radius: 100%;
 	border: 1px solid #c3c4c7;
-	background: #fff;
+	/*background: #fff;*/
+	background: var(--wp-admin--background);
 }
 
 .control-panel-themes .theme-section .customize-themes-section-title.selected:after {
@@ -1939,12 +2012,15 @@ p.customize-section-description {
 	position: absolute;
 	top: 9px;
 	right: 15px;
-	background: #2271b1;
-	color: #fff;
+	/*background: #2271b1;*/
+	background: var(--wp-admin--background);
+	/*color: #fff;*/
+	color: var(--wp-admin--color);
 }
 
 .control-panel-themes .customize-themes-section-title.selected {
-	color: #2271b1;
+	/*color: #2271b1;*/
+	color: var(--wp-admin--color);
 }
 
 #customize-theme-controls .themes.accordion-section-content {
@@ -1979,11 +2055,14 @@ p.customize-section-description {
 	width: 100%;
 	margin: 0;
 	border: 1px solid #dcdcde;
-	background: #fff;
+	/*background: #fff;*/
+	background: var(--wp-admin--background);
+
 }
 
 .customize-control-theme .theme .theme-name, .customize-control-theme .theme .theme-actions {
-	background: #fff;
+	/*background: #fff;*/
+	background: var(--wp-admin--background);
 	border: none;
 }
 
@@ -2055,7 +2134,8 @@ p.customize-section-description {
 	left: 300px;
 	width: calc(100% - 300px);
 	height: 46px;
-	background: #f0f0f1;
+	/*background: #f0f0f1;*/
+	background: var(--wp-admin--background);
 	z-index: 10;
 	padding: 6px 25px;
 	box-sizing: border-box;
@@ -2180,8 +2260,10 @@ p.customize-section-description {
 		position: fixed;
 		top: 0;
 		left: 0;
-		background: #f0f0f1;
-		color: #3c434a;
+		/*background: #f0f0f1;*/
+		background: var(--wp-admin--background);
+		/*color: #3c434a;*/
+		color: var(--wp-admin--color);
 		border-radius: 0;
 		box-shadow: none;
 		border: none;
@@ -2211,8 +2293,10 @@ p.customize-section-description {
 
 	.wp-customizer .showing-themes .control-panel-themes .customize-themes-mobile-back:hover,
 	.wp-customizer .showing-themes .control-panel-themes .customize-themes-mobile-back:focus {
-		color: #2271b1;
-		background: #f6f7f7;
+		/*color: #2271b1;*/
+		color: var(--wp-admin--color);
+		/*background: #f6f7f7;*/
+		background: var(--wp-admin--background);
 		border-left-color: #2271b1;
 		box-shadow: none;
 		/* Only visible in Windows High Contrast mode */
@@ -2256,7 +2340,8 @@ p.customize-section-description {
 }
 
 .wp-customizer .theme-overlay .theme-backdrop {
-	background: rgba(240, 240, 241, 0.75);
+	/*background: rgba(240, 240, 241, 0.75);*/
+	background: var(--wp-admin--background);
 	position: fixed;
 	z-index: 110;
 }
@@ -2281,7 +2366,8 @@ p.customize-section-description {
 .wp-customizer .theme-overlay .theme-actions {
 	text-align: right; /* Because there're only one or two actions, match the UI pattern of media modals and right-align the action. */
 	padding: 10px 25px;
-	background: #f0f0f1;
+	/*background: #f0f0f1;*/
+	background: var(--wp-admin--background);
 	border-top: 1px solid #dcdcde;
 }
 
@@ -2301,12 +2387,14 @@ p.customize-section-description {
 }
 
 .wp-customizer .theme-header {
-	background: #f0f0f1;
+	/*background: #f0f0f1;*/
+	background: var(--wp-admin--background);
 }
 
 .wp-customizer .theme-overlay .theme-header button,
 .wp-customizer .theme-overlay .theme-header .close:before {
-	color: #3c434a;
+	/*color: #3c434a;*/
+	color: var(--wp-admin--color);
 }
 
 .wp-customizer .theme-overlay .theme-header .close:focus,
@@ -2315,22 +2403,27 @@ p.customize-section-description {
 .wp-customizer .theme-overlay .theme-header .right:hover,
 .wp-customizer .theme-overlay .theme-header .left:focus,
 .wp-customizer .theme-overlay .theme-header .left:hover {
-	background: #fff;
+	/*background: #fff;*/
+	background: var(--wp-admin--background);
 	border-bottom: 4px solid #2271b1;
-	color: #2271b1;
+	/*color: #2271b1;*/
+	color: var(--wp-admin--color);
 }
 
 .wp-customizer .theme-overlay .theme-header .close:focus:before,
 .wp-customizer .theme-overlay .theme-header .close:hover:before {
-	color: #2271b1;
+	/*color: #2271b1;*/
+	color: var(--wp-admin--color);
 }
 
 .wp-customizer .theme-overlay .theme-header button.disabled,
 .wp-customizer .theme-overlay .theme-header button.disabled:hover,
 .wp-customizer .theme-overlay .theme-header button.disabled:focus {
 	border-bottom: none;
-	background: transparent;
-	color: #c3c4c7;
+	/*background: transparent;*/
+	background: var(--wp-admin--background);
+	/*color: #c3c4c7;*/
+	color: var(--wp-admin--color);
 }
 
 /* Small Screens */
@@ -2351,7 +2444,8 @@ p.customize-section-description {
 body.cheatin {
 	font-size: medium;
 	height: auto;
-	background: #fff;
+	/*background: #fff;*/
+	background: var(--wp-admin--background);
 	border: 1px solid #c3c4c7;
 	margin: 50px auto 2em;
 	padding: 1em 2em;
@@ -2363,7 +2457,8 @@ body.cheatin {
 body.cheatin h1 {
 	border-bottom: 1px solid #dcdcde;
 	clear: both;
-	color: #50575e;
+	/*color: #50575e;*/
+	color: var(--wp-admin--color);
 	font-size: 24px;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	margin: 30px 0 0 0;
@@ -2442,7 +2537,8 @@ body.cheatin p {
 	display: block;
 	width: 33px; /* was 42px for mobile */
 	height: 43px;
-	color: #8c8f94;
+	/*color: #8c8f94;*/
+	color: var(--wp-admin--color);
 	text-indent: -9999px;
 	cursor: pointer;
 	outline: none;
@@ -2451,7 +2547,8 @@ body.cheatin p {
 .menu-item-reorder-nav button {
 	width: 30px;
 	height: 40px;
-	background: transparent;
+	/*background: transparent;*/
+	background: var(--wp-admin--background);
 	border: none;
 	box-shadow: none;
 }
@@ -2475,8 +2572,10 @@ body.cheatin p {
 .widget-reorder-nav span:focus,
 .menu-item-reorder-nav button:hover,
 .menu-item-reorder-nav button:focus {
-	color: #1d2327;
-	background: #f0f0f1;
+	/*color: #1d2327;*/
+	color: var(--wp-admin--color);
+	/*background: #f0f0f1;*/
+	background: var(--wp-admin--background);
 }
 
 .move-widget-down:before,
@@ -2495,8 +2594,10 @@ body.cheatin p {
 .move-down-disabled .menus-move-down,
 .move-right-disabled .menus-move-right,
 .move-left-disabled .menus-move-left {
-	color: #dcdcde;
-	background-color: #fff;
+	/*color: #dcdcde;*/
+	color: var(--wp-admin--color);
+	/*background-color: #fff;*/
+	background-color: var(--wp-admin--background-color);
 	cursor: default;
 	pointer-events: none;
 }
@@ -2516,9 +2617,12 @@ body.adding-widget .add-new-widget:hover,
 .adding-menu-items .add-new-menu-item:hover,
 .add-menu-toggle.open,
 .add-menu-toggle.open:hover {
-	background: #f0f0f1;
-	border-color: #8c8f94;
-	color: #2c3338;
+	/*background: #f0f0f1;*/
+	background: var(--wp-admin--background);
+	/*border-color: #8c8f94;*/
+	border-color: var(--wp-admin--border-color);
+	/*color: #2c3338;*/
+	color: var(--wp-admin--color);
 	box-shadow: inset 0 2px 5px -3px rgba(0, 0, 0, 0.5);
 }
 
@@ -2540,7 +2644,8 @@ body.adding-widget .add-new-widget:before,
 	width: 300px;
 	margin: 0;
 	z-index: 4;
-	background: #f0f0f1;
+	/*background: #f0f0f1;*/
+	background: var(--wp-admin--background);
 	transition: left .18s;
 	border-right: 1px solid #dcdcde;
 }
@@ -2568,7 +2673,8 @@ body.adding-widget .add-new-widget:before,
 	top: 0;
 	z-index: 1;
 	width: 300px;
-	background: #f0f0f1;
+	/*background: #f0f0f1;*/
+	background: var(--wp-admin--background);
 }
 
 /* search field container */
@@ -2601,7 +2707,8 @@ body.adding-widget .add-new-widget:before,
 	height: 30px;
 	line-height: 2.1;
 	text-align: center;
-	color: #646970;
+	/*color: #646970;*/
+	color: var(--wp-admin--color);
 }
 
 #available-widgets-filter .clear-results,
@@ -2614,8 +2721,10 @@ body.adding-widget .add-new-widget:before,
 	padding: 0;
 	border: 0;
 	cursor: pointer;
-	background: none;
-	color: #d63638;
+	/*background: none;*/
+	background: var(--wp-admin--background);
+	/*color: #d63638;*/
+	color: var(--wp-admin--color);
 	text-decoration: none;
 	outline: 0;
 }
@@ -2644,7 +2753,8 @@ body.adding-widget .add-new-widget:before,
 #available-widgets-filter .clear-results:focus,
 #available-menu-items-search .clear-results:hover,
 #available-menu-items-search .clear-results:focus {
-	color: #d63638;
+	/*color: #d63638;*/
+	color: var(--wp-admin--color);
 }
 
 #available-widgets-filter .clear-results:focus,
@@ -2669,7 +2779,8 @@ body.adding-widget .add-new-widget:before,
 	top: 7px;
 	left: 26px;
 	z-index: 1;
-	color: #646970;
+	/*color: #646970;*/
+	color: var(--wp-admin--color);
 	height: 30px;
 	width: 30px;
 	line-height: 2;
@@ -2692,7 +2803,8 @@ body.adding-widget .add-new-widget:before,
 #available-menu-items .item-top,
 #available-menu-items .item-top:hover {
 	border: none;
-	background: transparent;
+	/*background: transparent;*/
+	background: var(--wp-admin--background);
 	box-shadow: none;
 }
 
@@ -2700,7 +2812,8 @@ body.adding-widget .add-new-widget:before,
 #available-menu-items .item-tpl {
 	position: relative;
 	padding: 15px 15px 15px 60px;
-	background: #fff;
+	/*background: #fff;*/
+	background: var(--wp-admin--background);
 	border-bottom: 1px solid #dcdcde;
 	border-left: 4px solid #fff;
 	transition:
@@ -2820,11 +2933,13 @@ body.adding-widget .add-new-widget:before,
 		padding: 0 12px 4px;
 		margin: 0;
 		height: 45px;
-		background: #f0f0f1;
+		/*background: #f0f0f1;*/
+		background: var(--wp-admin--background);
 		border: 0;
 		border-right: 1px solid #dcdcde;
 		border-top: 4px solid #f0f0f1;
-		color: #50575e;
+		/*color: #50575e;*/
+		color: var(--wp-admin--color);
 		cursor: pointer;
 		transition: color .1s ease-in-out, background .1s ease-in-out;
 	}
@@ -2899,7 +3014,8 @@ body.adding-widget .add-new-widget:before,
 		padding: 9px 10px 12px 14px;
 		margin: 0;
 		line-height: 24px;
-		color: #50575e;
+		/*color: #50575e;*/
+		color: var(--wp-admin--color);
 		display: block;
 		overflow: hidden;
 		white-space: nowrap;

--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -34,7 +34,7 @@ body {
 	padding: 25px 25px 25px 109px;
 	position: relative;
 	background: var(--wp-admin--customize-notification-changeset-locked-message--background);
-	box-shadow: 0 3px 6px rgba(0, 0, 0, 0.3);
+	box-shadow: 0 3px 6px rgba(var(--wp-admin--customize-notification-changeset-locked-message--box-shadow-color), 0.3);
 	line-height: 1.5;
 	overflow-y: auto;
 	text-align: left;
@@ -80,7 +80,8 @@ body:not(.ready) #customize-save-button-wrapper .save {
 }
 
 #customize-save-button-wrapper .save:focus, #publish-settings:focus {
-	box-shadow: 0 1px 0 #2271b1, 0 0 2px 1px #72aee6; /* This is default box shadow for focus */
+	box-shadow: 0 1px 0 var(--wp-admin--customize-save-button--box-shadow-color_bottom--focus),
+	0 0 2px 1px var(--wp-admin--customize-save-button--box-shadow-color_top-and-sides--focus); /* This is default box shadow for focus */
 }
 
 #customize-save-button-wrapper .save.has-next-sibling {
@@ -100,8 +101,8 @@ body:not(.ready) #customize-save-button-wrapper .save {
 	z-index: -1;
 	background: var(--wp-admin--customize-sidebar-outer-content--background);
 	transition: left .18s;
-	border-right: 1px solid #dcdcde;
-	border-left: 1px solid #dcdcde;
+	border-right: 1px solid var(--wp-admin--customize-sidebar-outer-content--border-right-color);
+	border-left: 1px solid var(--wp-admin--customize-sidebar-outer-content--border-left-color);
 	height: 100%;
 }
 
@@ -179,7 +180,7 @@ body.trashing #publish-settings {
 }
 
 #customize-header-actions {
-	border-bottom: 1px solid #dcdcde;
+	border-bottom: 1px solid var(--wp-admin-customize-header-actions--border-bottom-color);
 }
 
 #customize-controls .wp-full-overlay-sidebar-content {
@@ -193,14 +194,14 @@ body.trashing #publish-settings {
 
 #customize-controls .customize-info {
 	border: none;
-	border-bottom: 1px solid #dcdcde;
+	border-bottom: 1px solid var(--wp-admin--customize-controls-info--border-bottom-color);
 	margin-bottom: 15px;
 }
 
 #customize-control-changeset_status .customize-inside-control-row,
 #customize-control-changeset_preview_link input {
 	background-color: var(--wp-admin--customize-control-changeset-inside-control-row--background-color);
-	border-bottom: 1px solid #dcdcde;
+	border-bottom: 1px solid var(--wp-admin--customize-control-changeset-inside-control-row--border-bottom-color);
 	box-sizing: content-box;
 	width: 100%;
 	margin-left: -12px;
@@ -236,7 +237,7 @@ body.trashing #publish-settings {
 }
 
 #customize-control-changeset_status .customize-inside-control-row:first-of-type {
-	border-top: 1px solid #dcdcde;
+	border-top: 1px solid var(--wp-admin--customize-control-changeset-inside-control-row--border-top-color--first-of-type);
 }
 
 #customize-control-changeset_status .customize-control-title {
@@ -286,7 +287,7 @@ body.trashing #publish-settings {
 
 #customize-control-changeset_preview_link input {
 	line-height: 2.85714286; /* 40px */
-	border-top: 1px solid #dcdcde;
+	border-top: 1px solid var(--wp-admin--customize-control-changeset_preview_link-input--border-top-color);
 	border-left: none;
 	border-right: none;
 	text-indent: -999px;
@@ -377,7 +378,7 @@ body.trashing #publish-settings {
 	margin-left: -12px;
 	padding: 12px;
 	background: var(--wp-admin--customize-control-changeset_scheduled_date--background);
-	border-bottom: 1px solid #dcdcde;
+	border-bottom: 1px solid var(--wp-admin--customize-control-changeset_scheduled_date--border-bottom-color);
 	margin-bottom: 0;
 }
 
@@ -390,7 +391,7 @@ body.trashing #publish-settings {
 	position: absolute;
 	z-index: 9;
 	width: 100%;
-	box-shadow: 0 1px 0 rgba(0, 0, 0, 0.1);
+	box-shadow: 0 1px 0 rgba(var(--wp-admin--customize-controls-info-is-in-view--box-shadow-color), 0.1);
 }
 
 #customize-controls .customize-section-title.is-in-view {
@@ -486,11 +487,11 @@ body.trashing #publish-settings {
 	display: none;
 	background: var(--wp-admin--customize-controls-customize-panel-description--background);
 	padding: 12px 15px;
-	border-top: 1px solid #dcdcde;
+	border-top: 1px solid var(--wp-admin--customize-controls-customize-panel-description--border-top-color);
 }
 
 #customize-controls .customize-info .customize-panel-description.open + .no-widget-areas-rendered-notice {
-	border-top: none;
+	border-top: var(--wp-admin--customize-controls-panel-description-open--border-top-color);
 }
 .no-widget-areas-rendered-notice {
 	font-style: italic;
@@ -529,8 +530,8 @@ body.trashing #publish-settings {
 #customize-outer-theme-controls .accordion-section-title {
 	color: var(--wp-admin--customize-theme-controls-accordion-section-title--color);
 	background-color: var(--wp-admin--customize-theme-controls-accordion-section-title--background-color);
-	border-bottom: 1px solid #dcdcde;
-	border-left: 4px solid #fff;
+	border-bottom: 1px solid var(--wp-admin--customize-theme-controls-accordion-section-title--border-bottom-color);
+	border-left: 4px solid var(--wp-admin--customize-theme-controls-accordion-section-title--border-left-color);
 	transition:
 		.15s color ease-in-out,
 		.15s background-color ease-in-out,
@@ -540,7 +541,7 @@ body.trashing #publish-settings {
 #customize-controls #customize-theme-controls .customize-themes-panel .accordion-section-title {
 	color: var(--wp-admin--customize-theme-controls-accordion-section-title--color);
 	background-color: var(--wp-admin--customize-theme-controls-accordion-section-title--background-color);
-	border-left: 4px solid #fff;
+	border-left: 4px solid var(--wp-admin--customize-theme-controls-accordion-section-title--border-left-color);
 }
 
 #customize-theme-controls .accordion-section-title:after,
@@ -561,11 +562,11 @@ body.trashing #publish-settings {
 #customize-controls .control-section .accordion-section-title:focus {
 	color: var(--wp-admin--customize-controls-control-section-title--color);
 	background: var(--wp-admin--customize-controls-control-section-title--background);
-	border-left-color: #2271b1;
+	border-left-color: var(--wp-admin--customize-controls-control-section-accordion-title--border-left-color);
 }
 
 #accordion-section-themes + .control-section {
-	border-top: 1px solid #dcdcde;
+	border-top: 1px solid var(--wp-admin--customize-accordion-section-themes-control-section--border-top-color);
 }
 
 .js .control-section:hover .accordion-section-title,
@@ -587,27 +588,27 @@ body.trashing #publish-settings {
 }
 
 #customize-theme-controls .control-section.open {
-	border-bottom: 1px solid #f0f0f1;
+	border-bottom: 1px solid var(--wp-admin--customize-theme-controls-section-open--border-bottom-color);
 }
 
 #customize-theme-controls .control-section.open .accordion-section-title,
 #customize-outer-theme-controls .control-section.open .accordion-section-title {
-	border-bottom-color: #f0f0f1 !important;
+	border-bottom-color: var(--wp-admin--customize-theme-controls-accordion-section-title--border-bottom-color) !important;
 }
 
 #customize-theme-controls .control-section:last-of-type.open,
 #customize-theme-controls .control-section:last-of-type > .accordion-section-title {
-	border-bottom-color: #dcdcde;
+	border-bottom-color: var(--wp-admin--customize-theme-controls-section--border-bottom-color--last-of-type-open);
 }
 
 #customize-theme-controls .control-panel-content:not(.control-panel-nav_menus) .control-section:nth-child(2),
 #customize-theme-controls .control-panel-nav_menus .control-section-nav_menu,
 #customize-theme-controls .control-section-nav_menu_locations .accordion-section-title {
-	border-top: 1px solid #dcdcde;
+	border-top: 1px solid var(--wp-admin--customize-theme-controls-section--border-top-color--nth-child-2);
 }
 
 #customize-theme-controls .control-panel-nav_menus .control-section-nav_menu + .control-section-nav_menu {
-	border-top: none;
+	border-top: var(--wp-admin--customize-theme-controls-section-nav_menu--border-top-color);
 }
 
 #customize-theme-controls > ul {
@@ -717,7 +718,7 @@ body.trashing #publish-settings {
 
 .customize-section-title {
 	margin: -12px -12px 0 -12px;
-	border-bottom: 1px solid #dcdcde;
+	border-bottom: 1px solid var(--wp-admin--customize-section-title--border-bottom-color);
 	background: var(--wp-admin--customize-section-title--background);
 }
 
@@ -738,7 +739,7 @@ div.customize-section-description p:last-child {
 }
 
 #customize-theme-controls .customize-themes-panel h3.customize-section-title:first-child {
-	border-bottom: 1px solid #dcdcde;
+	border-bottom: 1px solid var(--wp-admin--customize-theme-controls-section-title--border-bottom-color--first-child);
 	padding: 12px 12px 12px 12px;
 }
 
@@ -779,8 +780,8 @@ h3.customize-section-title {
 	padding: 0 2px 0 0;
 	background: var(--wp-admin--customize-controls-close--background);
 	border: none;
-	border-top: 4px solid #f0f0f1;
-	border-right: 1px solid #dcdcde;
+	border-top: 4px solid var(--wp-admin--customize-controls-close--border-top-color);
+	border-right: 1px solid var(--wp-admin--customize-controls-close--border-right-color);
 	color: var(--wp-admin--customize-controls-close--color);
 	text-align: left;
 	cursor: pointer;
@@ -801,8 +802,8 @@ h3.customize-section-title {
 	margin: 0;
 	background: var(--wp-admin--customize-panel-back--background);
 	border: none;
-	border-right: 1px solid #dcdcde;
-	border-left: 4px solid #fff;
+	border-right: 1px solid var(--wp-admin--customize-panel-back--border-right-color);
+	border-left: 4px solid var(--wp-admin--customize-panel-back--border-left-color);
 	box-shadow: none;
 	cursor: pointer;
 	transition:
@@ -832,7 +833,7 @@ h3.customize-section-title {
 #customize-controls .cannot-expand:hover .accordion-section-title {
 	background: var(--wp-admin--customize-controls-accordion-section-title--background--hover);
 	color: var(--wp-admin--customize-controls-accordion-section-title--color--hover);
-	border-left-color: #fff;
+	border-left-color: var(--wp-admin--customize-controls-accordion-section-title--border-left-color--hover);
 }
 
 .customize-controls-close:focus,
@@ -841,7 +842,7 @@ h3.customize-section-title {
 .customize-controls-preview-toggle:hover {
 	background: var(--wp-admin--customize-controls-close--background--focus);
 	color: var(--wp-admin--customize-controls-close--color--focus);
-	border-top-color: #2271b1;
+	border-top-color: var(--wp-admin--customize-controls-close--border-top-color--focus);
 	box-shadow: none;
 	/* Only visible in Windows High Contrast mode */
 	outline: 1px solid transparent;
@@ -859,7 +860,7 @@ h3.customize-section-title {
 .customize-section-back:focus {
 	color: var(--wp-admin--customize-panel-back--color--hover);
 	background: var(--wp-admin--customize-panel-back--background--hover);
-	border-left-color: #2271b1;
+	border-left-color: var(--wp-admin--customize-panel-back--border-left-color--hover);
 	box-shadow: none;
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
@@ -1084,7 +1085,7 @@ p.customize-section-description {
 }
 
 .customize-control-dropdown-pages .new-content-item .create-item-input.invalid {
-	border: 1px solid #d63638;
+	border: 1px solid var(--wp-admin--customize-control-create-page-item-input_invalid--border-color);
 }
 
 .customize-control-dropdown-pages .add-new-toggle {
@@ -1104,7 +1105,7 @@ p.customize-section-description {
 
 .wp-full-overlay-sidebar {
 	background: var(--wp-admin--customize-full-overlay-sidebar--background);
-	border-right: 1px solid #dcdcde;
+	border-right: 1px solid var(--wp-admin--customize-full-overlay-sidebar--border-right-color);
 }
 
 
@@ -1120,7 +1121,7 @@ p.customize-section-description {
 
 #customize-controls .customize-control-widget_form.has-error .widget .widget-top,
 .customize-control-nav_menu_item.has-error .menu-item-bar .menu-item-handle {
-	box-shadow: inset 0 0 0 2px #d63638;
+	box-shadow: inset 0 0 0 2px var(--wp-admin--customize-controls-widget-form-has-error--box-shadow-color_inset);
 	transition: .15s box-shadow linear;
 }
 
@@ -1147,14 +1148,14 @@ p.customize-section-description {
 }
 
 .customize-control-text.has-error input {
-	outline: 2px solid #d63638;
+	outline: 2px solid var(--wp-admin--customize-control-text-has-error-input--outline);
 }
 
 #customize-controls #customize-notifications-area {
 	position: absolute;
 	top: 46px;
 	width: 100%;
-	border-bottom: 1px solid #dcdcde;
+	border-bottom: 1px solid var(--wp-admin-customize-controls-notification-area--border-bottom-color);
 	display: block;
 	padding: 0;
 	margin: 0;
@@ -1182,7 +1183,7 @@ p.customize-section-description {
 }
 #customize-controls .panel-meta > .customize-control-notifications-container,
 #customize-controls .customize-section-title > .customize-control-notifications-container {
-	border-top: 1px solid #dcdcde;
+	border-top: 1px solid var(--wp-admin-customize-controls-notification-container--border-top-color);
 }
 #customize-controls #customize-notifications-area .notice,
 #customize-controls .panel-meta > .customize-control-notifications-container .notice,
@@ -1263,7 +1264,7 @@ p.customize-section-description {
 	line-height: 16px;
 	margin-right: 16px;
 	padding: 4px 5px;
-	border: 2px solid #f0f0f1;
+	border: 2px solid var(--wp-admin--customize-accordion-section-dropdown-content--border-color);
 	-webkit-user-select: none;
 	user-select: none;
 }
@@ -1307,11 +1308,11 @@ p.customize-section-description {
 
 .customize-control-color .dropdown .dropdown-content {
 	background-color: var(--wp-admin--customize-dropdown-content--background-color);
-	border: 1px solid rgba(0, 0, 0, 0.15);
+	border: 1px solid rgba(var(--wp-admin--customize-dropdown-content--border-color), 0.15);
 }
 
 .customize-control-color .dropdown:hover .dropdown-content {
-	border-color: rgba(0, 0, 0, 0.25);
+	border-color: rgba(var(--wp-admin-customize-control-color-dropdown-content--border-color--hover), 0.25);
 }
 
 /**
@@ -1375,7 +1376,7 @@ p.customize-section-description {
 	position: relative;
 	text-align: center;
 	cursor: default;
-	border: 1px dashed #c3c4c7;
+	border: 1px dashed var(--wp-admin--customize-control-placeholder--border-color);
 	box-sizing: border-box;
 	padding: 9px 0;
 	line-height: 1.6;
@@ -1393,9 +1394,9 @@ p.customize-section-description {
 
 .customize-control .attachment-media-view .button-add-media:focus {
 	background-color: var(--wp-admin--customize-button-add-media--background-color--focus);
-	border-color: #3582c4;
+	border-color: var(--wp-admin--customize-button-add-media--border-color--focus);
 	border-style: solid;
-	box-shadow: 0 0 0 1px #3582c4;
+	box-shadow: 0 0 0 1px var(--wp-admin--customize-button-add-media--box-shadow-color--focus);
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 }
@@ -1448,7 +1449,7 @@ p.customize-section-description {
 	left: 0;
 	bottom: 0;
 	right: 0;
-	border: 4px solid #72aee6;
+	border: 4px solid var(--wp-admin--customize-control-header-view-selected--border-color--after);
 	border-radius: 2px;
 }
 
@@ -1462,8 +1463,6 @@ p.customize-section-description {
 	font-size: 20px;
 	color: var(--wp-admin--customize-control-header-close--color);
 	background: var(--wp-admin--customize-control-header-close--background);
-	/* The following background value will prevail in the cascade.*/
-	background: rgba(0, 0, 0, 0.5);
 	position: absolute;
 	top: 10px;
 	left: -999px;
@@ -1480,7 +1479,7 @@ p.customize-section-description {
 }
 
 .customize-control-header .header-view .close:focus {
-	outline: 1px solid #4f94d4;
+	outline: 1px solid var(--wp-admin--customize-control-header-view-close--outline--focus);
 }
 
 /* Header control: randomiz(s)er */
@@ -1542,8 +1541,8 @@ p.customize-section-description {
 .customize-control-header .choice:focus {
 	outline: none;
 	box-shadow:
-		0 0 0 1px #4f94d4,
-		0 0 3px 1px rgba(79, 148, 212, 0.8);
+		0 0 0 1px var(--wp-admin--customize-control-header-choice--box-shadow-color_first-outer-box--focus),
+		0 0 3px 1px var(--wp-admin--customize-control-header-choice--box-shadow-color_second-outer-box--focus);
 }
 
 .customize-control-header .uploaded div:last-child > .choice {
@@ -1635,7 +1634,7 @@ p.customize-section-description {
 .theme-browser .theme.active .theme-actions,
 .wp-customizer .theme-browser .theme .theme-actions {
 	padding: 9px 15px;
-	box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.1);
+	box-shadow: inset 0 1px 0 rgba(var(--wp-admin--customize-theme-actions--box-shadow-color), 0.1);
 }
 
 @media screen and (max-width: 640px) {
@@ -1661,8 +1660,8 @@ p.customize-section-description {
 	cursor: default;
 	background: var(--wp-admin--customize-theme-controls-control-panel-themes-title--background--hover);
 	color: var(--wp-admin--customize-theme-controls-control-panel-themes-title--color--hover);
-	border-top: 1px solid #dcdcde;
-	border-bottom: 1px solid #dcdcde;
+	border-top: 1px solid var(--wp-admin--customize-theme-controls-control-panel-themes-title--border-top-color--hover);
+	border-bottom: 1px solid var(--wp-admin--customize-theme-controls-control-panel-themes-title--border-bottom-color--hover);
 	border-left: none;
 	border-right: none;
 	margin: 0 0 15px 0;
@@ -1723,7 +1722,7 @@ p.customize-section-description {
 	background: var(--wp-admin--customize-control-panel-themes-full-container--background);
 	z-index: 20;
 }
-/* STOP WORK 08-29-2021 */
+
 @media screen and (min-width: 1670px) {
 	.control-panel-themes .customize-themes-full-container {
 		width: 82%;
@@ -1797,7 +1796,7 @@ p.customize-section-description {
 .themes-filter-bar .feature-filter-toggle.open {
 	background: var(--wp-admin--customize-themes-feature-filter-toggle-open--background);
 	border-color: var(--wp-admin--customize-themes-feature-filter-toggle-open--border-color);
-	box-shadow: inset 0 2px 5px -3px rgba(0, 0, 0, 0.5);
+	box-shadow: inset 0 2px 5px -3px rgba(var(--wp-admin--customize-themes-feature-filter-toggle-open--box-shadow-color_inset), 0.5);
 }
 
 .themes-filter-bar .feature-filter-toggle .filter-count-filters {
@@ -1814,7 +1813,7 @@ p.customize-section-description {
 	border-top: 0;
 	margin: 0;
 	background: var(--wp-admin--customize-filter-drawer--background);
-	border-bottom: 1px solid #dcdcde;
+	border-bottom: 1px solid var(--wp-admin--customize-filter-drawer--border-bottom-color);
 }
 
 .filter-drawer .filter-group {
@@ -1877,7 +1876,7 @@ p.customize-section-description {
 	padding: 0 0 8px 15px;
 	margin: 15px 0 0 0;
 	line-height: 16px;
-	border-bottom: 1px solid #dcdcde;
+	border-bottom: 1px solid var(--wp-admin--customize-control-section-text-before--border-bottom-color);
 	color: var(--wp-admin--customize-control-section-text-before--color);
 }
 
@@ -1887,8 +1886,8 @@ p.customize-section-description {
 	box-shadow: none;
 	outline: none;
 	border-top: none;
-	border-bottom: 1px solid #dcdcde;
-	border-left: 4px solid #fff;
+	border-bottom: 1px solid var(--wp-admin--customize-control-panel-themes-section-title--border-bottom-color);
+	border-left: 4px solid var(--wp-admin--customize-control-panel-themes-section-title--border-left-color);
 	border-right: none;
 	cursor: pointer;
 	padding: 10px 15px;
@@ -1901,7 +1900,7 @@ p.customize-section-description {
 }
 
 .control-panel-themes #accordion-section-installed_themes {
-	border-top: 1px solid #dcdcde;
+	border-top: 1px solid var(--wp-admin--customize-accordion-section-installed_themes--border-top-color);
 }
 
 .control-panel-themes .theme-section {
@@ -1911,7 +1910,7 @@ p.customize-section-description {
 
 .control-panel-themes .customize-themes-section-title:focus,
 .control-panel-themes .customize-themes-section-title:hover {
-	border-left-color: #2271b1;
+	border-left-color: var(--wp-admin--customize-control-panel-themes-section-title--border-left-color--focus);
 	color: var(--wp-admin--customize-control-panel-themes-section-title--color--focus);
 	background: var(--wp-admin--customize-control-panel-themes-section-title--background--focus);
 }
@@ -1925,7 +1924,7 @@ p.customize-section-description {
 	width: 18px;
 	height: 18px;
 	border-radius: 100%;
-	border: 1px solid #c3c4c7;
+	border: 1px solid var(--wp-admin--customize-themes-section-title-not-selected--border-color--after);
 	background: var(--wp-admin--customize-themes-section-title-not-selected--background--after);
 }
 
@@ -1979,7 +1978,7 @@ p.customize-section-description {
 .customize-control-theme .theme {
 	width: 100%;
 	margin: 0;
-	border: 1px solid #dcdcde;
+	border: 1px solid var(--wp-admin--customize-control-theme--border-color);
 	background: var(--wp-admin--customize-control-theme--background);
 
 }
@@ -2061,7 +2060,7 @@ p.customize-section-description {
 	z-index: 10;
 	padding: 6px 25px;
 	box-sizing: border-box;
-	border-bottom: 1px solid #dcdcde;
+	border-bottom: 1px solid var(--wp-admin--customize-preview-header-themes-filter-bar--border-bottom-color);
 }
 
 @media screen and (min-width: 1670px) {
@@ -2192,8 +2191,8 @@ p.customize-section-description {
 		z-index: 10;
 		text-align: left;
 		text-shadow: none;
-		border-bottom: 1px solid #dcdcde;
-		border-left: 4px solid transparent;
+		border-bottom: 1px solid var(--wp-admin--customize-themes-mobile-back--border-bottom-color);
+		border-left: 4px solid var(--wp-admin--customize-themes-mobile-back--border-left-color);
 		margin: 0;
 		padding: 0;
 		font-size: 0;
@@ -2208,14 +2207,14 @@ p.customize-section-description {
 		display: block;
 		line-height: 2.3;
 		padding: 0 8px 0 8px;
-		border-right: 1px solid #dcdcde;
+		border-right: 1px solid var(--wp-admin--customize-themes-mobile-back--border-right-color--before);
 	}
 
 	.wp-customizer .showing-themes .control-panel-themes .customize-themes-mobile-back:hover,
 	.wp-customizer .showing-themes .control-panel-themes .customize-themes-mobile-back:focus {
 		color: var(--wp-admin--customize-themes-mobile-back--color--hover);
 		background: var(--wp-admin--customize-themes-mobile-back--background--hover);
-		border-left-color: #2271b1;
+		border-left-color: var(--wp-admin--customize-themes-mobile-back--border-left-color--hover);
 		box-shadow: none;
 		/* Only visible in Windows High Contrast mode */
 		outline: 2px solid transparent;
@@ -2284,7 +2283,7 @@ p.customize-section-description {
 	text-align: right; /* Because there're only one or two actions, match the UI pattern of media modals and right-align the action. */
 	padding: 10px 25px;
 	background: var(--wp-admin--customize-theme-actions--background);
-	border-top: 1px solid #dcdcde;
+	border-top: 1px solid var(--wp-admin--customize-theme-actions--border-top-color);
 }
 
 .wp-customizer .theme-overlay .theme-actions .theme-install.preview {
@@ -2318,7 +2317,7 @@ p.customize-section-description {
 .wp-customizer .theme-overlay .theme-header .left:focus,
 .wp-customizer .theme-overlay .theme-header .left:hover {
 	background: var(--wp-admin--customize-theme-header-close--background--focus);
-	border-bottom: 4px solid #2271b1;
+	border-bottom: 4px solid var(--wp-admin--customize-theme-header-close--border-bottom-color--focus);
 	color: var(--wp-admin--customize-theme-header-close--color--focus);
 }
 
@@ -2354,16 +2353,16 @@ body.cheatin {
 	font-size: medium;
 	height: auto;
 	background: var(--wp-admin--customize-cheatin--background);
-	border: 1px solid #c3c4c7;
+	border: 1px solid var(--wp-admin--customize-cheatin--border-color);
 	margin: 50px auto 2em;
 	padding: 1em 2em;
 	max-width: 700px;
 	min-width: 0;
-	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+	box-shadow: 0 1px 1px rgba(var(--wp-admin--customize-cheatin--box-shadow-color), 0.04);
 }
 
 body.cheatin h1 {
-	border-bottom: 1px solid #dcdcde;
+	border-bottom: 1px solid var(--wp-admin--customize-cheatin-h1--border-bottom-color);
 	clear: both;
 	color: var(--wp-admin--customize-cheatin-h1--color);
 	font-size: 24px;
@@ -2521,7 +2520,7 @@ body.adding-widget .add-new-widget:hover,
 	background: var(--wp-admin--customize-add-new-widget--background);
 	border-color: var(--wp-admin--customize-add-new-widget--border-color);
 	color: var(--wp-admin--customize-add-new-widget--color);
-	box-shadow: inset 0 2px 5px -3px rgba(0, 0, 0, 0.5);
+	box-shadow: inset 0 2px 5px -3px rgba(var(--wp-admin--customize-add-new-widget--box-shadow-color_inset), 0.5);
 }
 
 body.adding-widget .add-new-widget:before,
@@ -2544,7 +2543,7 @@ body.adding-widget .add-new-widget:before,
 	z-index: 4;
 	background: var(--wp-admin--customize-available-widgets--background);
 	transition: left .18s;
-	border-right: 1px solid #dcdcde;
+	border-right: 1px solid var(--wp-admin--customize-available-widgets--border-right-color);
 }
 
 #available-widgets .customize-section-title,
@@ -2558,7 +2557,7 @@ body.adding-widget .add-new-widget:before,
 	overflow: auto;
 	bottom: 0;
 	width: 100%;
-	border-top: 1px solid #dcdcde;
+	border-top: 1px solid var(--wp-admin--customize-available-widgets--border-top-color);
 }
 
 .no-widgets-found #available-widgets-list {
@@ -2651,9 +2650,9 @@ body.adding-widget .add-new-widget:before,
 
 #available-widgets-filter .clear-results:focus,
 #available-menu-items-search .clear-results:focus {
-	box-shadow:
-		0 0 0 1px #4f94d4,
-		0 0 2px 1px rgba(79, 148, 212, 0.8);
+	box-shadow: 0 0 0 1px var(--wp-admin--customize-available-widgets-filter-clear-results--box-shadow-color_first-outer-box--focus),
+	0 0 2px 1px var(--wp-admin--customize-available-widgets-filter-clear-results--box-shadow-color_second-outer-box--focus);
+
 }
 
 #available-menu-items-search .search-icon:after,
@@ -2703,8 +2702,8 @@ body.adding-widget .add-new-widget:before,
 	position: relative;
 	padding: 15px 15px 15px 60px;
 	background: var(--wp-admin--customize-available-widgets-template--background);
-	border-bottom: 1px solid #dcdcde;
-	border-left: 4px solid #fff;
+	border-bottom: 1px solid var(--wp-admin--customize-available-widgets-template--border-bottom-color);
+	border-left: 4px solid var(--wp-admin--customize-available-widgets-template--border-left-color);
 	transition:
 		.15s color ease-in-out,
 		.15s background-color ease-in-out,
@@ -2824,8 +2823,8 @@ body.adding-widget .add-new-widget:before,
 		height: 45px;
 		background: var(--wp-admin--customize-controls-preview-toggle-small-screen--background);
 		border: 0;
-		border-right: 1px solid #dcdcde;
-		border-top: 4px solid #f0f0f1;
+		border-right: 1px solid var(--wp-admin--customize-controls-preview-toggle-small-screen--border-right-color);
+		border-top: 4px solid var(--wp-admin--customize-controls-preview-toggle-small-screen--border-top-color);
 		color: var(--wp-admin--customize-controls-preview-toggle-small-screen--color);
 		cursor: pointer;
 		transition: color .1s ease-in-out, background .1s ease-in-out;

--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -22,7 +22,7 @@ body {
 
 #customize-controls #customize-notifications-area .notice.notification-overlay.notification-changeset-locked {
 	/*background-color: rgba(0, 0, 0, 0.7);*/
-	background-color: var(--wp-admin--background-color);
+	background-color: var(--wp-admin--customize-notification-changeset-locked--background-color);
 	padding: 25px;
 }
 
@@ -35,7 +35,7 @@ body {
 	padding: 25px 25px 25px 109px;
 	position: relative;
 	/*background: #fff;*/
-	background: var(--wp-admin--customize-changeset-locked-message--background);
+	background: var(--wp-admin--customize-notification-changeset-locked-message--background);
 	box-shadow: 0 3px 6px rgba(0, 0, 0, 0.3);
 	line-height: 1.5;
 	overflow-y: auto;
@@ -64,7 +64,7 @@ body {
 
 #customize-controls .description {
 	/*color: #50575e;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-controls-description--color);
 }
 
 #customize-save-button-wrapper {
@@ -205,7 +205,7 @@ body.trashing #publish-settings {
 #customize-control-changeset_status .customize-inside-control-row,
 #customize-control-changeset_preview_link input {
 	/*background-color: #fff;*/
-	background-color: var(--wp-admin--customize-inside-control-row--background-color);
+	background-color: var(--wp-admin--customize-control-changeset-inside-control-row--background-color);
 	border-bottom: 1px solid #dcdcde;
 	box-sizing: content-box;
 	width: 100%;
@@ -233,7 +233,7 @@ body.trashing #publish-settings {
 
 #customize-controls .date-input:invalid {
 	/*border-color: #d63638;*/
-	border-color: var(--wp-admin--border-color);
+	border-color: var(--wp-admin--customize-controls-date-input--border-color--invalid);
 }
 
 #customize-control-changeset_status .customize-inside-control-row {
@@ -299,7 +299,7 @@ body.trashing #publish-settings {
 	border-right: none;
 	text-indent: -999px;
 	/*color: #fff;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-control-changeset-preview-input--color);
 	/* Only necessary for IE11 */
 	min-height: 40px;
 }
@@ -325,7 +325,7 @@ body.trashing #publish-settings {
 #customize-control-changeset_preview_link a.disabled:focus,
 #customize-control-changeset_preview_link a.disabled:visited {
 	/*color: #000;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-control-changeset-preview-disabled--color);
 	opacity: 0.4;
 	cursor: default;
 	outline: none;
@@ -422,7 +422,7 @@ body.trashing #publish-settings {
 	/*background: #fff;*/
 	background: var(--wp-admin--background);
 	/*color: #50575e;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-controls-accordion-section-title--color);
 	border-left: none;
 	border-right: none;
 	border-bottom: none;
@@ -433,7 +433,7 @@ body.trashing #publish-settings {
 #customize-controls .customize-info .accordion-section-title:hover:after,
 #customize-controls .customize-info .accordion-section-title:focus:after {
 	/*color: #2c3338;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-controls-accordion-section-title--color--after);
 }
 
 #customize-controls .customize-info .accordion-section-title:after {
@@ -476,9 +476,9 @@ body.trashing #publish-settings {
 	box-shadow: none;
 	-webkit-appearance: none;
 	/*background: transparent;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-controls-customize-help-toggle--background);
 	/*color: #50575e;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-controls-customize-help-toggle--color);
 	border: none;
 }
 
@@ -492,7 +492,7 @@ body.trashing #publish-settings {
 #customize-controls .customize-info .customize-help-toggle:focus,
 #customize-controls .customize-info .customize-help-toggle:hover {
 	/*color: #2271b1;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-controls-customize-help-toggle--color);
 }
 
 #customize-controls .customize-info .customize-panel-description,
@@ -500,10 +500,10 @@ body.trashing #publish-settings {
 #customize-outer-theme-controls .customize-info .customize-section-description,
 #customize-controls .no-widget-areas-rendered-notice {
 	/*color: #50575e;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-controls-customize-panel-description--color);
 	display: none;
 	/*background: #fff;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-controls-customize-panel-description--background);
 	padding: 12px 15px;
 	border-top: 1px solid #dcdcde;
 }
@@ -547,9 +547,9 @@ body.trashing #publish-settings {
 #customize-theme-controls .accordion-section-title,
 #customize-outer-theme-controls .accordion-section-title {
 	/*color: #50575e;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-theme-controls-accordion-section-title--color);
 	/*background-color: #fff;*/
-	background-color: var(--wp-admin--background-color);
+	background-color: var(--wp-admin--customize-theme-controls-accordion-section-title--background-color);
 	border-bottom: 1px solid #dcdcde;
 	border-left: 4px solid #fff;
 	transition:
@@ -560,9 +560,9 @@ body.trashing #publish-settings {
 
 #customize-controls #customize-theme-controls .customize-themes-panel .accordion-section-title {
 	/*color: #50575e;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-theme-controls-accordion-section-title--color);
 	/*background-color: #fff;*/
-	background-color: var(--wp-admin--background-color);
+	background-color: var(--wp-admin--customize-theme-controls-accordion-section-title--background-color);
 	border-left: 4px solid #fff;
 }
 
@@ -570,15 +570,15 @@ body.trashing #publish-settings {
 #customize-outer-theme-controls .accordion-section-title:after {
 	content: "\f345";
 	/*color: #a7aaad;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-theme-controls-accordion-section-title--color--after);
 }
 
 #customize-theme-controls .accordion-section-content,
 #customize-outer-theme-controls .accordion-section-content {
 	/*color: #50575e;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-theme-controls-accordion-section-content--color);
 	/*background: transparent;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-theme-controls-accordion-section-content--background);
 }
 
 #customize-controls .control-section:hover > .accordion-section-title,
@@ -586,9 +586,9 @@ body.trashing #publish-settings {
 #customize-controls .control-section.open .accordion-section-title,
 #customize-controls .control-section .accordion-section-title:focus {
 	/*color: #2271b1;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-controls-accordion-section-title--color);
 	/*background: #f6f7f7;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-controls-accordion-section-title--background);
 	border-left-color: #2271b1;
 }
 
@@ -613,7 +613,7 @@ body.trashing #publish-settings {
 #customize-outer-theme-controls .control-section.open .accordion-section-title:after,
 #customize-outer-theme-controls .control-section .accordion-section-title:focus:after {
 	/*color: #2271b1;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-theme-controls-accordion-section-title--color--after);
 }
 
 #customize-theme-controls .control-section.open {
@@ -783,7 +783,7 @@ h3.customize-section-title {
 	margin: 0;
 	line-height: 21px;
 	/*color: #50575e;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-section-title-h3--color);
 }
 
 .accordion-sub-container.control-panel-content {
@@ -810,12 +810,12 @@ h3.customize-section-title {
 	height: 41px;
 	padding: 0 2px 0 0;
 	/*background: #f0f0f1;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-controls-close--background);
 	border: none;
 	border-top: 4px solid #f0f0f1;
 	border-right: 1px solid #dcdcde;
 	/*color: #3c434a;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-controls-close--color);
 	text-align: left;
 	cursor: pointer;
 	transition:
@@ -866,9 +866,9 @@ h3.customize-section-title {
 #customize-controls .panel-meta.customize-info .accordion-section-title:hover,
 #customize-controls .cannot-expand:hover .accordion-section-title {
 	/*background: #fff;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-controls-accordion-section-title--background--hover);
 	/*color: #50575e;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-controls-accordion-section-title--color--hover);
 	border-left-color: #fff;
 }
 
@@ -877,9 +877,9 @@ h3.customize-section-title {
 .customize-controls-preview-toggle:focus,
 .customize-controls-preview-toggle:hover {
 	/*background: #fff;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-controls-preview-toggle--background--focus);
 	/*color: #2271b1;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-controls-preview-toggle--color--focus);
 	border-top-color: #2271b1;
 	box-shadow: none;
 	/* Only visible in Windows High Contrast mode */
@@ -897,9 +897,9 @@ h3.customize-section-title {
 .customize-section-back:hover,
 .customize-section-back:focus {
 	/*color: #2271b1;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-panel-back--color--hover);
 	/*background: #f6f7f7;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-panel-back--background--hover);
 	border-left-color: #2271b1;
 	box-shadow: none;
 	/* Only visible in Windows High Contrast mode */
@@ -925,7 +925,7 @@ h3.customize-section-title {
 
 .wp-full-overlay-sidebar .wp-full-overlay-header {
 	/*background-color: #f0f0f1;*/
-	background-color: var(--wp-admin--background-color);
+	background-color: var(--wp-admin--full-overlay-header--background-color);
 	transition: padding ease-in-out .18s;
 }
 
@@ -1264,7 +1264,7 @@ p.customize-section-description {
 #customize-controls #customize-notifications-area .notice.notification-overlay .notification-message {
 	clear: both;
 	/*color: #1d2327;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-notification-message--color);
 	font-size: 18px;
 	font-style: normal;
 	margin: 0;
@@ -1321,7 +1321,7 @@ p.customize-section-description {
 	right: 0;
 	width: 20px;
 	/*background: #f0f0f1;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-dropdown-arrow--background);
 }
 
 .customize-control .dropdown-arrow:after {
@@ -1337,14 +1337,14 @@ p.customize-section-description {
 	-moz-osx-font-smoothing: grayscale;
 	text-decoration: none !important;
 	/*color: #2c3338;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-dropdown-arrow--color--after);
 }
 
 .customize-control .dropdown-status {
 	/*color: #2c3338;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-dropdown-status--color);
 	/*background: #f0f0f1;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-dropdown-status--background);
 	display: none;
 	max-width: 112px;
 }
@@ -1356,7 +1356,7 @@ p.customize-section-description {
 
 .customize-control-color .dropdown .dropdown-content {
 	/*background-color: #50575e;*/
-	background-color: var(--wp-admin--background-color);
+	background-color: var(--wp-admin--customize-dropdown-content--background-color);
 	border: 1px solid rgba(0, 0, 0, 0.15);
 }
 
@@ -1394,10 +1394,10 @@ p.customize-section-description {
 	padding: 0;
 	margin: 0;
 	/*background: none;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-uploaded-button--background);
 	border: none;
 	/*color: inherit;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-uploaded-button--color);
 	cursor: pointer;
 }
 
@@ -1436,19 +1436,19 @@ p.customize-section-description {
 .customize-control .attachment-media-view .button-add-media {
 	cursor: pointer;
 	/*background-color: #f0f0f1;*/
-	background-color: var(--wp-admin--background-color);
+	background-color: var(--wp-admin--customize-button-add-media--color);
 	/*color: #2c3338;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-button-add-media--color);
 }
 
 .customize-control .attachment-media-view .button-add-media:hover {
 	/*background-color: #fff;*/
-	background-color: var(--wp-admin--background-color);
+	background-color: var(--wp-admin--customize-button-add-media--background-color--hover);
 }
 
 .customize-control .attachment-media-view .button-add-media:focus {
 	/*background-color: #fff;*/
-	background-color: var(--wp-admin--background-color);
+	background-color: var(--wp-admin--customize-button-add-media--background-color--focus);
 	border-color: #3582c4;
 	border-style: solid;
 	box-shadow: 0 0 0 1px #3582c4;
@@ -1461,7 +1461,7 @@ p.customize-section-description {
 	position: absolute;
 	width: 100%;
 	/*color: #50575e;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-header-inner--color);
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow: hidden;
@@ -1518,9 +1518,9 @@ p.customize-section-description {
 .customize-control-header .uploaded .header-view .close {
 	font-size: 20px;
 	/*color: #fff;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-header-close--color);
 	/*background: #50575e;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-header-close--background);
 	background: rgba(0, 0, 0, 0.5);
 	position: absolute;
 	top: 10px;
@@ -1720,7 +1720,7 @@ p.customize-section-description {
 	/*background: #fff;*/
 	background: var(--wp-admin--background);
 	/*color: #50575e;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-theme-controls-accordion-section-title--color--hover);
 	border-top: 1px solid #dcdcde;
 	border-bottom: 1px solid #dcdcde;
 	border-left: none;
@@ -1858,9 +1858,9 @@ p.customize-section-description {
 
 .themes-filter-bar .feature-filter-toggle.open {
 	/*background: #f0f0f1;*/
-	background: var(--wp-admin--background);
-	border-color: #8c8f94;
-	border-color: var(--wp-admin--border-color);
+	background: var(--wp-admin--themes-feature-filter-toggle-open--background);
+	/*border-color: #8c8f94;*/
+	border-color: var(--wp-admin--themes-feature-filter-toggle-open--border-color);
 	box-shadow: inset 0 2px 5px -3px rgba(0, 0, 0, 0.5);
 }
 
@@ -1919,7 +1919,7 @@ p.customize-section-description {
 .control-panel-themes .filter-themes-count .themes-displayed {
 	font-weight: 600;
 	/*color: #50575e;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-control-panel-themes-displayed--color);
 }
 
 .customize-themes-notifications {
@@ -1945,13 +1945,13 @@ p.customize-section-description {
 	line-height: 16px;
 	border-bottom: 1px solid #dcdcde;
 	/*color: #50575e;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-control-section-text-before--color);
 }
 
 .control-panel-themes .customize-themes-section-title {
 	width: 100%;
 	/*background: #fff;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-control-panel-themes-section-title--background);
 	box-shadow: none;
 	outline: none;
 	border-top: none;
@@ -1965,7 +1965,7 @@ p.customize-section-description {
 	font-size: 14px;
 	font-weight: 600;
 	/*color: #50575e;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-control-panel-themes-section-title--color);
 	text-shadow: none;
 }
 
@@ -1982,9 +1982,9 @@ p.customize-section-description {
 .control-panel-themes .customize-themes-section-title:hover {
 	border-left-color: #2271b1;
 	/*color: #2271b1;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-themes-section-title--color--focus);
 	/*background: #f6f7f7;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-themes-section-title--background--focus);
 }
 
 .customize-themes-section-title:not(.selected):after {
@@ -2013,14 +2013,14 @@ p.customize-section-description {
 	top: 9px;
 	right: 15px;
 	/*background: #2271b1;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-themes-section-title-selected--background--after);
 	/*color: #fff;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-themes-section-title-selected--color--after);
 }
 
 .control-panel-themes .customize-themes-section-title.selected {
 	/*color: #2271b1;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-themes-section-title-selected--color);
 }
 
 #customize-theme-controls .themes.accordion-section-content {
@@ -2261,9 +2261,9 @@ p.customize-section-description {
 		top: 0;
 		left: 0;
 		/*background: #f0f0f1;*/
-		background: var(--wp-admin--background);
+		background: var(--wp-admin--customize-themes-mobile-back--background);
 		/*color: #3c434a;*/
-		color: var(--wp-admin--color);
+		color: var(--wp-admin--customize-themes-mobile-back--color);
 		border-radius: 0;
 		box-shadow: none;
 		border: none;
@@ -2294,9 +2294,9 @@ p.customize-section-description {
 	.wp-customizer .showing-themes .control-panel-themes .customize-themes-mobile-back:hover,
 	.wp-customizer .showing-themes .control-panel-themes .customize-themes-mobile-back:focus {
 		/*color: #2271b1;*/
-		color: var(--wp-admin--color);
+		color: var(--wp-admin--customize-themes-mobile-back--color--hover);
 		/*background: #f6f7f7;*/
-		background: var(--wp-admin--background);
+		background: var(--wp-admin--customize-themes-mobile-back--background--hover);
 		border-left-color: #2271b1;
 		box-shadow: none;
 		/* Only visible in Windows High Contrast mode */
@@ -2394,7 +2394,7 @@ p.customize-section-description {
 .wp-customizer .theme-overlay .theme-header button,
 .wp-customizer .theme-overlay .theme-header .close:before {
 	/*color: #3c434a;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-theme-header-button--color);
 }
 
 .wp-customizer .theme-overlay .theme-header .close:focus,
@@ -2404,16 +2404,16 @@ p.customize-section-description {
 .wp-customizer .theme-overlay .theme-header .left:focus,
 .wp-customizer .theme-overlay .theme-header .left:hover {
 	/*background: #fff;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-theme-header-close--background);
 	border-bottom: 4px solid #2271b1;
 	/*color: #2271b1;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-theme-header-close--color--focus);
 }
 
 .wp-customizer .theme-overlay .theme-header .close:focus:before,
 .wp-customizer .theme-overlay .theme-header .close:hover:before {
 	/*color: #2271b1;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-theme-header-close--color--focus--before);
 }
 
 .wp-customizer .theme-overlay .theme-header button.disabled,
@@ -2421,9 +2421,9 @@ p.customize-section-description {
 .wp-customizer .theme-overlay .theme-header button.disabled:focus {
 	border-bottom: none;
 	/*background: transparent;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-theme-header-button-disabled--background);
 	/*color: #c3c4c7;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-theme-header-button-disabled--color);
 }
 
 /* Small Screens */
@@ -2458,7 +2458,7 @@ body.cheatin h1 {
 	border-bottom: 1px solid #dcdcde;
 	clear: both;
 	/*color: #50575e;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--cheatin-h1--color);
 	font-size: 24px;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	margin: 30px 0 0 0;
@@ -2538,7 +2538,7 @@ body.cheatin p {
 	width: 33px; /* was 42px for mobile */
 	height: 43px;
 	/*color: #8c8f94;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-widget-reorder-nav--color);
 	text-indent: -9999px;
 	cursor: pointer;
 	outline: none;
@@ -2573,9 +2573,9 @@ body.cheatin p {
 .menu-item-reorder-nav button:hover,
 .menu-item-reorder-nav button:focus {
 	/*color: #1d2327;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-widget-reorder-nav--color--hover);
 	/*background: #f0f0f1;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-widget-reorder-nav--background);
 }
 
 .move-widget-down:before,
@@ -2595,9 +2595,9 @@ body.cheatin p {
 .move-right-disabled .menus-move-right,
 .move-left-disabled .menus-move-left {
 	/*color: #dcdcde;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-theme-controls-move-widget-up--color);
 	/*background-color: #fff;*/
-	background-color: var(--wp-admin--background-color);
+	background-color: var(--wp-admin--customize-theme-controls-move-widget-up--background-color);
 	cursor: default;
 	pointer-events: none;
 }
@@ -2618,11 +2618,11 @@ body.adding-widget .add-new-widget:hover,
 .add-menu-toggle.open,
 .add-menu-toggle.open:hover {
 	/*background: #f0f0f1;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-add-new-widget--background);
 	/*border-color: #8c8f94;*/
-	border-color: var(--wp-admin--border-color);
+	border-color: var(--wp-admin--customize-add-new-widget--border-color);
 	/*color: #2c3338;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-add-new-widget--color);
 	box-shadow: inset 0 2px 5px -3px rgba(0, 0, 0, 0.5);
 }
 
@@ -2708,7 +2708,7 @@ body.adding-widget .add-new-widget:before,
 	line-height: 2.1;
 	text-align: center;
 	/*color: #646970;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-search-icon--color);
 }
 
 #available-widgets-filter .clear-results,
@@ -2722,9 +2722,9 @@ body.adding-widget .add-new-widget:before,
 	border: 0;
 	cursor: pointer;
 	/*background: none;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-available-widgets-filter-clear-results--background);
 	/*color: #d63638;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-available-widgets-filter-clear-results--color);
 	text-decoration: none;
 	outline: 0;
 }
@@ -2754,7 +2754,7 @@ body.adding-widget .add-new-widget:before,
 #available-menu-items-search .clear-results:hover,
 #available-menu-items-search .clear-results:focus {
 	/*color: #d63638;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-available-widgets-filter-clear-results--color--hover);
 }
 
 #available-widgets-filter .clear-results:focus,
@@ -2780,7 +2780,7 @@ body.adding-widget .add-new-widget:before,
 	left: 26px;
 	z-index: 1;
 	/*color: #646970;*/
-	color: var(--wp-admin--color);
+	color: var(--wp-admin--customize-themes-filter-bar-search-icon--color);
 	height: 30px;
 	width: 30px;
 	line-height: 2;
@@ -2813,7 +2813,7 @@ body.adding-widget .add-new-widget:before,
 	position: relative;
 	padding: 15px 15px 15px 60px;
 	/*background: #fff;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-available-widgets-template--background);
 	border-bottom: 1px solid #dcdcde;
 	border-left: 4px solid #fff;
 	transition:
@@ -2934,12 +2934,12 @@ body.adding-widget .add-new-widget:before,
 		margin: 0;
 		height: 45px;
 		/*background: #f0f0f1;*/
-		background: var(--wp-admin--background);
+		background: var(--wp-admin--customize-controls-preview-toggle-small-screen--background);
 		border: 0;
 		border-right: 1px solid #dcdcde;
 		border-top: 4px solid #f0f0f1;
 		/*color: #50575e;*/
-		color: var(--wp-admin--color);
+		color: var(--wp-admin--customize-controls-preview-toggle-small-screen--color);
 		cursor: pointer;
 		transition: color .1s ease-in-out, background .1s ease-in-out;
 	}
@@ -3015,7 +3015,7 @@ body.adding-widget .add-new-widget:before,
 		margin: 0;
 		line-height: 24px;
 		/*color: #50575e;*/
-		color: var(--wp-admin--color);
+		color: var(--wp-admin--customize-available-widgets-section-title-small-screen--color);
 		display: block;
 		overflow: hidden;
 		white-space: nowrap;

--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -1343,9 +1343,9 @@ p.customize-section-description {
 	width: 100%;
 	padding: 0;
 	margin: 0;
-	background: var(--wp-admin--customize-uploaded-button--background);
+	background: var(--wp-admin--customize-uploaded-button--background--not-random);
 	border: none;
-	color: var(--wp-admin--customize-uploaded-button--color);
+	color: var(--wp-admin--customize-uploaded-button--color--not-random);
 	cursor: pointer;
 }
 

--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -21,7 +21,6 @@ body {
 }
 
 #customize-controls #customize-notifications-area .notice.notification-overlay.notification-changeset-locked {
-	/*background-color: rgba(0, 0, 0, 0.7);*/
 	background-color: var(--wp-admin--customize-notification-changeset-locked--background-color);
 	padding: 25px;
 }
@@ -34,7 +33,6 @@ body {
 	width: auto;
 	padding: 25px 25px 25px 109px;
 	position: relative;
-	/*background: #fff;*/
 	background: var(--wp-admin--customize-notification-changeset-locked-message--background);
 	box-shadow: 0 3px 6px rgba(0, 0, 0, 0.3);
 	line-height: 1.5;
@@ -63,7 +61,6 @@ body {
 }
 
 #customize-controls .description {
-	/*color: #50575e;*/
 	color: var(--wp-admin--customize-controls-description--color);
 }
 
@@ -101,7 +98,6 @@ body:not(.ready) #customize-save-button-wrapper .save {
 	width: 100%;
 	margin: 0;
 	z-index: -1;
-	/*background: #f0f0f1;*/
 	background: var(--wp-admin--customize-sidebar-outer-content--background);
 	transition: left .18s;
 	border-right: 1px solid #dcdcde;
@@ -192,8 +188,7 @@ body.trashing #publish-settings {
 }
 
 .outer-section-open #customize-controls .wp-full-overlay-sidebar-content {
-	/*background: #f0f0f1;*/
-	background: var(--wp-admin--full-overlay-sidebar-content--background);
+	background: var(--wp-admin--customize-controls-full-overlay-sidebar-content--background);
 }
 
 #customize-controls .customize-info {
@@ -204,7 +199,6 @@ body.trashing #publish-settings {
 
 #customize-control-changeset_status .customize-inside-control-row,
 #customize-control-changeset_preview_link input {
-	/*background-color: #fff;*/
 	background-color: var(--wp-admin--customize-control-changeset-inside-control-row--background-color);
 	border-bottom: 1px solid #dcdcde;
 	box-sizing: content-box;
@@ -232,7 +226,6 @@ body.trashing #publish-settings {
 }
 
 #customize-controls .date-input:invalid {
-	/*border-color: #d63638;*/
 	border-color: var(--wp-admin--customize-controls-date-input--border-color--invalid);
 }
 
@@ -275,8 +268,7 @@ body.trashing #publish-settings {
 	content: "";
 	height: 28px;
 	position: absolute;
-	/*background: #fff;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-copy-preview-link--background--before);
 	top: -1px;
 }
 
@@ -298,8 +290,7 @@ body.trashing #publish-settings {
 	border-left: none;
 	border-right: none;
 	text-indent: -999px;
-	/*color: #fff;*/
-	color: var(--wp-admin--customize-control-changeset-preview-input--color);
+	color: var(--wp-admin--customize-control-changeset_preview_link-input--color);
 	/* Only necessary for IE11 */
 	min-height: 40px;
 }
@@ -324,8 +315,7 @@ body.trashing #publish-settings {
 #customize-control-changeset_preview_link a.disabled:active,
 #customize-control-changeset_preview_link a.disabled:focus,
 #customize-control-changeset_preview_link a.disabled:visited {
-	/*color: #000;*/
-	color: var(--wp-admin--customize-control-changeset-preview-disabled--color);
+	color: var(--wp-admin--customize-control-changeset_preview_link-disabled--color);
 	opacity: 0.4;
 	cursor: default;
 	outline: none;
@@ -386,8 +376,7 @@ body.trashing #publish-settings {
 	width: 100%;
 	margin-left: -12px;
 	padding: 12px;
-	/*background: #fff;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-control-changeset_scheduled_date--background);
 	border-bottom: 1px solid #dcdcde;
 	margin-bottom: 0;
 }
@@ -419,9 +408,7 @@ body.trashing #publish-settings {
 }
 
 #customize-controls .customize-info .accordion-section-title {
-	/*background: #fff;*/
-	background: var(--wp-admin--background);
-	/*color: #50575e;*/
+	background: var(--wp-admin--customize-controls-accordion-section-title--background);
 	color: var(--wp-admin--customize-controls-accordion-section-title--color);
 	border-left: none;
 	border-right: none;
@@ -432,7 +419,6 @@ body.trashing #publish-settings {
 #customize-controls .customize-info.open .accordion-section-title:after,
 #customize-controls .customize-info .accordion-section-title:hover:after,
 #customize-controls .customize-info .accordion-section-title:focus:after {
-	/*color: #2c3338;*/
 	color: var(--wp-admin--customize-controls-accordion-section-title--color--after);
 }
 
@@ -475,9 +461,7 @@ body.trashing #publish-settings {
 	cursor: pointer;
 	box-shadow: none;
 	-webkit-appearance: none;
-	/*background: transparent;*/
 	background: var(--wp-admin--customize-controls-customize-help-toggle--background);
-	/*color: #50575e;*/
 	color: var(--wp-admin--customize-controls-customize-help-toggle--color);
 	border: none;
 }
@@ -491,18 +475,15 @@ body.trashing #publish-settings {
 #customize-controls .customize-info.open .customize-help-toggle,
 #customize-controls .customize-info .customize-help-toggle:focus,
 #customize-controls .customize-info .customize-help-toggle:hover {
-	/*color: #2271b1;*/
-	color: var(--wp-admin--customize-controls-customize-help-toggle--color);
+	color: var(--wp-admin--customize-controls-customize-info-open-help-toggle--color);
 }
 
 #customize-controls .customize-info .customize-panel-description,
 #customize-controls .customize-info .customize-section-description,
 #customize-outer-theme-controls .customize-info .customize-section-description,
 #customize-controls .no-widget-areas-rendered-notice {
-	/*color: #50575e;*/
 	color: var(--wp-admin--customize-controls-customize-panel-description--color);
 	display: none;
-	/*background: #fff;*/
 	background: var(--wp-admin--customize-controls-customize-panel-description--background);
 	padding: 12px 15px;
 	border-top: 1px solid #dcdcde;
@@ -546,9 +527,7 @@ body.trashing #publish-settings {
 
 #customize-theme-controls .accordion-section-title,
 #customize-outer-theme-controls .accordion-section-title {
-	/*color: #50575e;*/
 	color: var(--wp-admin--customize-theme-controls-accordion-section-title--color);
-	/*background-color: #fff;*/
 	background-color: var(--wp-admin--customize-theme-controls-accordion-section-title--background-color);
 	border-bottom: 1px solid #dcdcde;
 	border-left: 4px solid #fff;
@@ -559,9 +538,7 @@ body.trashing #publish-settings {
 }
 
 #customize-controls #customize-theme-controls .customize-themes-panel .accordion-section-title {
-	/*color: #50575e;*/
 	color: var(--wp-admin--customize-theme-controls-accordion-section-title--color);
-	/*background-color: #fff;*/
 	background-color: var(--wp-admin--customize-theme-controls-accordion-section-title--background-color);
 	border-left: 4px solid #fff;
 }
@@ -569,15 +546,12 @@ body.trashing #publish-settings {
 #customize-theme-controls .accordion-section-title:after,
 #customize-outer-theme-controls .accordion-section-title:after {
 	content: "\f345";
-	/*color: #a7aaad;*/
 	color: var(--wp-admin--customize-theme-controls-accordion-section-title--color--after);
 }
 
 #customize-theme-controls .accordion-section-content,
 #customize-outer-theme-controls .accordion-section-content {
-	/*color: #50575e;*/
 	color: var(--wp-admin--customize-theme-controls-accordion-section-content--color);
-	/*background: transparent;*/
 	background: var(--wp-admin--customize-theme-controls-accordion-section-content--background);
 }
 
@@ -585,10 +559,8 @@ body.trashing #publish-settings {
 #customize-controls .control-section .accordion-section-title:hover,
 #customize-controls .control-section.open .accordion-section-title,
 #customize-controls .control-section .accordion-section-title:focus {
-	/*color: #2271b1;*/
-	color: var(--wp-admin--customize-controls-accordion-section-title--color);
-	/*background: #f6f7f7;*/
-	background: var(--wp-admin--customize-controls-accordion-section-title--background);
+	color: var(--wp-admin--customize-controls-control-section-title--color);
+	background: var(--wp-admin--customize-controls-control-section-title--background);
 	border-left-color: #2271b1;
 }
 
@@ -600,8 +572,7 @@ body.trashing #publish-settings {
 .js .control-section .accordion-section-title:hover,
 .js .control-section.open .accordion-section-title,
 .js .control-section .accordion-section-title:focus {
-	/*background: #f6f7f7;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-js-control-section-title--background);
 }
 
 #customize-theme-controls .control-section:hover > .accordion-section-title:after,
@@ -612,8 +583,7 @@ body.trashing #publish-settings {
 #customize-outer-theme-controls .control-section .accordion-section-title:hover:after,
 #customize-outer-theme-controls .control-section.open .accordion-section-title:after,
 #customize-outer-theme-controls .control-section .accordion-section-title:focus:after {
-	/*color: #2271b1;*/
-	color: var(--wp-admin--customize-theme-controls-accordion-section-title--color--after);
+	color: var(--wp-admin--customize-theme-controls-section-title--color--after);
 }
 
 #customize-theme-controls .control-section.open {
@@ -748,8 +718,7 @@ body.trashing #publish-settings {
 .customize-section-title {
 	margin: -12px -12px 0 -12px;
 	border-bottom: 1px solid #dcdcde;
-	/*background: #fff;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-section-title--background);
 }
 
 div.customize-section-description {
@@ -782,7 +751,6 @@ h3.customize-section-title {
 	padding: 10px 10px 12px 14px;
 	margin: 0;
 	line-height: 21px;
-	/*color: #50575e;*/
 	color: var(--wp-admin--customize-section-title-h3--color);
 }
 
@@ -809,12 +777,10 @@ h3.customize-section-title {
 	width: 45px;
 	height: 41px;
 	padding: 0 2px 0 0;
-	/*background: #f0f0f1;*/
 	background: var(--wp-admin--customize-controls-close--background);
 	border: none;
 	border-top: 4px solid #f0f0f1;
 	border-right: 1px solid #dcdcde;
-	/*color: #3c434a;*/
 	color: var(--wp-admin--customize-controls-close--color);
 	text-align: left;
 	cursor: pointer;
@@ -833,8 +799,7 @@ h3.customize-section-title {
 	height: 71px;
 	padding: 0 24px 0 0;
 	margin: 0;
-	/*background: #fff;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-panel-back--background);
 	border: none;
 	border-right: 1px solid #dcdcde;
 	border-left: 4px solid #fff;
@@ -865,9 +830,7 @@ h3.customize-section-title {
 
 #customize-controls .panel-meta.customize-info .accordion-section-title:hover,
 #customize-controls .cannot-expand:hover .accordion-section-title {
-	/*background: #fff;*/
 	background: var(--wp-admin--customize-controls-accordion-section-title--background--hover);
-	/*color: #50575e;*/
 	color: var(--wp-admin--customize-controls-accordion-section-title--color--hover);
 	border-left-color: #fff;
 }
@@ -876,10 +839,8 @@ h3.customize-section-title {
 .customize-controls-close:hover,
 .customize-controls-preview-toggle:focus,
 .customize-controls-preview-toggle:hover {
-	/*background: #fff;*/
-	background: var(--wp-admin--customize-controls-preview-toggle--background--focus);
-	/*color: #2271b1;*/
-	color: var(--wp-admin--customize-controls-preview-toggle--color--focus);
+	background: var(--wp-admin--customize-controls-close--background--focus);
+	color: var(--wp-admin--customize-controls-close--color--focus);
 	border-top-color: #2271b1;
 	box-shadow: none;
 	/* Only visible in Windows High Contrast mode */
@@ -896,9 +857,7 @@ h3.customize-section-title {
 .customize-panel-back:focus,
 .customize-section-back:hover,
 .customize-section-back:focus {
-	/*color: #2271b1;*/
 	color: var(--wp-admin--customize-panel-back--color--hover);
-	/*background: #f6f7f7;*/
 	background: var(--wp-admin--customize-panel-back--background--hover);
 	border-left-color: #2271b1;
 	box-shadow: none;
@@ -924,8 +883,7 @@ h3.customize-section-title {
 }
 
 .wp-full-overlay-sidebar .wp-full-overlay-header {
-	/*background-color: #f0f0f1;*/
-	background-color: var(--wp-admin--full-overlay-header--background-color);
+	background-color: var(--wp-admin--customize-full-overlay-header--background-color);
 	transition: padding ease-in-out .18s;
 }
 
@@ -1104,8 +1062,7 @@ p.customize-section-description {
 	position: absolute;
 	bottom: 0;
 	z-index: 10;
-	/*background: #f0f0f1;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-section-content-new-content-item--background);
 	display: flex;
 }
 
@@ -1146,8 +1103,7 @@ p.customize-section-description {
 }
 
 .wp-full-overlay-sidebar {
-	/*background: #f0f0f1;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-full-overlay-sidebar--background);
 	border-right: 1px solid #dcdcde;
 }
 
@@ -1263,7 +1219,6 @@ p.customize-section-description {
 /* Note: Styles for this are also defined in themes.css */
 #customize-controls #customize-notifications-area .notice.notification-overlay .notification-message {
 	clear: both;
-	/*color: #1d2327;*/
 	color: var(--wp-admin--customize-notification-message--color);
 	font-size: 18px;
 	font-style: normal;
@@ -1320,7 +1275,6 @@ p.customize-section-description {
 	bottom: 0;
 	right: 0;
 	width: 20px;
-	/*background: #f0f0f1;*/
 	background: var(--wp-admin--customize-dropdown-arrow--background);
 }
 
@@ -1336,14 +1290,11 @@ p.customize-section-description {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	text-decoration: none !important;
-	/*color: #2c3338;*/
 	color: var(--wp-admin--customize-dropdown-arrow--color--after);
 }
 
 .customize-control .dropdown-status {
-	/*color: #2c3338;*/
 	color: var(--wp-admin--customize-dropdown-status--color);
-	/*background: #f0f0f1;*/
 	background: var(--wp-admin--customize-dropdown-status--background);
 	display: none;
 	max-width: 112px;
@@ -1355,7 +1306,6 @@ p.customize-section-description {
 }
 
 .customize-control-color .dropdown .dropdown-content {
-	/*background-color: #50575e;*/
 	background-color: var(--wp-admin--customize-dropdown-content--background-color);
 	border: 1px solid rgba(0, 0, 0, 0.15);
 }
@@ -1393,10 +1343,8 @@ p.customize-section-description {
 	width: 100%;
 	padding: 0;
 	margin: 0;
-	/*background: none;*/
 	background: var(--wp-admin--customize-uploaded-button--background);
 	border: none;
-	/*color: inherit;*/
 	color: var(--wp-admin--customize-uploaded-button--color);
 	cursor: pointer;
 }
@@ -1435,19 +1383,15 @@ p.customize-section-description {
 
 .customize-control .attachment-media-view .button-add-media {
 	cursor: pointer;
-	/*background-color: #f0f0f1;*/
-	background-color: var(--wp-admin--customize-button-add-media--color);
-	/*color: #2c3338;*/
+	background-color: var(--wp-admin--customize-button-add-media--background-color);
 	color: var(--wp-admin--customize-button-add-media--color);
 }
 
 .customize-control .attachment-media-view .button-add-media:hover {
-	/*background-color: #fff;*/
 	background-color: var(--wp-admin--customize-button-add-media--background-color--hover);
 }
 
 .customize-control .attachment-media-view .button-add-media:focus {
-	/*background-color: #fff;*/
 	background-color: var(--wp-admin--customize-button-add-media--background-color--focus);
 	border-color: #3582c4;
 	border-style: solid;
@@ -1460,8 +1404,7 @@ p.customize-section-description {
 	display: none;
 	position: absolute;
 	width: 100%;
-	/*color: #50575e;*/
-	color: var(--wp-admin--customize-header-inner--color);
+	color: var(--wp-admin--customize-control-header-inner--color);
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow: hidden;
@@ -1517,10 +1460,9 @@ p.customize-section-description {
 
 .customize-control-header .uploaded .header-view .close {
 	font-size: 20px;
-	/*color: #fff;*/
-	color: var(--wp-admin--customize-header-close--color);
-	/*background: #50575e;*/
-	background: var(--wp-admin--customize-header-close--background);
+	color: var(--wp-admin--customize-control-header-close--color);
+	background: var(--wp-admin--customize-control-header-close--background);
+	/* The following background value will prevail in the cascade.*/
 	background: rgba(0, 0, 0, 0.5);
 	position: absolute;
 	top: 10px;
@@ -1717,10 +1659,8 @@ p.customize-section-description {
 #customize-theme-controls .control-panel-themes > .accordion-section-title:hover, /* Not a focusable element. */
 #customize-theme-controls .control-panel-themes > .accordion-section-title {
 	cursor: default;
-	/*background: #fff;*/
-	background: var(--wp-admin--background);
-	/*color: #50575e;*/
-	color: var(--wp-admin--customize-theme-controls-accordion-section-title--color--hover);
+	background: var(--wp-admin--customize-theme-controls-control-panel-themes-title--background--hover);
+	color: var(--wp-admin--customize-theme-controls-control-panel-themes-title--color--hover);
 	border-top: 1px solid #dcdcde;
 	border-bottom: 1px solid #dcdcde;
 	border-left: none;
@@ -1780,11 +1720,10 @@ p.customize-section-description {
 	overflow-y: scroll;
 	width: calc(100% - 300px);
 	height: calc(100% - 96px);
-	/*background: #f0f0f1;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-control-panel-themes-full-container--background);
 	z-index: 20;
 }
-
+/* STOP WORK 08-29-2021 */
 @media screen and (min-width: 1670px) {
 	.control-panel-themes .customize-themes-full-container {
 		width: 82%;
@@ -1818,8 +1757,7 @@ p.customize-section-description {
 }
 
 .wp-full-overlay.in-themes-panel {
-	/*background: #f0f0f1; !* Prevents a black flash when fading in the panel *!*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-full-overlay-in-themes-panel--background);
 }
 
 .in-themes-panel #customize-save-button-wrapper,
@@ -1857,10 +1795,8 @@ p.customize-section-description {
 }
 
 .themes-filter-bar .feature-filter-toggle.open {
-	/*background: #f0f0f1;*/
-	background: var(--wp-admin--themes-feature-filter-toggle-open--background);
-	/*border-color: #8c8f94;*/
-	border-color: var(--wp-admin--themes-feature-filter-toggle-open--border-color);
+	background: var(--wp-admin--customize-themes-feature-filter-toggle-open--background);
+	border-color: var(--wp-admin--customize-themes-feature-filter-toggle-open--border-color);
 	box-shadow: inset 0 2px 5px -3px rgba(0, 0, 0, 0.5);
 }
 
@@ -1877,8 +1813,7 @@ p.customize-section-description {
 	padding: 25px 0 25px 25px;
 	border-top: 0;
 	margin: 0;
-	/*background: #f0f0f1;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-filter-drawer--background);
 	border-bottom: 1px solid #dcdcde;
 }
 
@@ -1918,7 +1853,6 @@ p.customize-section-description {
 
 .control-panel-themes .filter-themes-count .themes-displayed {
 	font-weight: 600;
-	/*color: #50575e;*/
 	color: var(--wp-admin--customize-control-panel-themes-displayed--color);
 }
 
@@ -1944,13 +1878,11 @@ p.customize-section-description {
 	margin: 15px 0 0 0;
 	line-height: 16px;
 	border-bottom: 1px solid #dcdcde;
-	/*color: #50575e;*/
 	color: var(--wp-admin--customize-control-section-text-before--color);
 }
 
 .control-panel-themes .customize-themes-section-title {
 	width: 100%;
-	/*background: #fff;*/
 	background: var(--wp-admin--customize-control-panel-themes-section-title--background);
 	box-shadow: none;
 	outline: none;
@@ -1964,7 +1896,6 @@ p.customize-section-description {
 	text-align: left;
 	font-size: 14px;
 	font-weight: 600;
-	/*color: #50575e;*/
 	color: var(--wp-admin--customize-control-panel-themes-section-title--color);
 	text-shadow: none;
 }
@@ -1981,10 +1912,8 @@ p.customize-section-description {
 .control-panel-themes .customize-themes-section-title:focus,
 .control-panel-themes .customize-themes-section-title:hover {
 	border-left-color: #2271b1;
-	/*color: #2271b1;*/
-	color: var(--wp-admin--customize-themes-section-title--color--focus);
-	/*background: #f6f7f7;*/
-	background: var(--wp-admin--customize-themes-section-title--background--focus);
+	color: var(--wp-admin--customize-control-panel-themes-section-title--color--focus);
+	background: var(--wp-admin--customize-control-panel-themes-section-title--background--focus);
 }
 
 .customize-themes-section-title:not(.selected):after {
@@ -1997,8 +1926,7 @@ p.customize-section-description {
 	height: 18px;
 	border-radius: 100%;
 	border: 1px solid #c3c4c7;
-	/*background: #fff;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-themes-section-title-not-selected--background--after);
 }
 
 .control-panel-themes .theme-section .customize-themes-section-title.selected:after {
@@ -2012,15 +1940,12 @@ p.customize-section-description {
 	position: absolute;
 	top: 9px;
 	right: 15px;
-	/*background: #2271b1;*/
 	background: var(--wp-admin--customize-themes-section-title-selected--background--after);
-	/*color: #fff;*/
 	color: var(--wp-admin--customize-themes-section-title-selected--color--after);
 }
 
 .control-panel-themes .customize-themes-section-title.selected {
-	/*color: #2271b1;*/
-	color: var(--wp-admin--customize-themes-section-title-selected--color);
+	color: var(--wp-admin--customize-control-panel-themes-section-title-selected--color);
 }
 
 #customize-theme-controls .themes.accordion-section-content {
@@ -2055,14 +1980,12 @@ p.customize-section-description {
 	width: 100%;
 	margin: 0;
 	border: 1px solid #dcdcde;
-	/*background: #fff;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-control-theme--background);
 
 }
 
 .customize-control-theme .theme .theme-name, .customize-control-theme .theme .theme-actions {
-	/*background: #fff;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-control-theme-name--background);
 	border: none;
 }
 
@@ -2134,8 +2057,7 @@ p.customize-section-description {
 	left: 300px;
 	width: calc(100% - 300px);
 	height: 46px;
-	/*background: #f0f0f1;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-preview-header-themes-filter-bar--background);
 	z-index: 10;
 	padding: 6px 25px;
 	box-sizing: border-box;
@@ -2260,9 +2182,7 @@ p.customize-section-description {
 		position: fixed;
 		top: 0;
 		left: 0;
-		/*background: #f0f0f1;*/
 		background: var(--wp-admin--customize-themes-mobile-back--background);
-		/*color: #3c434a;*/
 		color: var(--wp-admin--customize-themes-mobile-back--color);
 		border-radius: 0;
 		box-shadow: none;
@@ -2293,9 +2213,7 @@ p.customize-section-description {
 
 	.wp-customizer .showing-themes .control-panel-themes .customize-themes-mobile-back:hover,
 	.wp-customizer .showing-themes .control-panel-themes .customize-themes-mobile-back:focus {
-		/*color: #2271b1;*/
 		color: var(--wp-admin--customize-themes-mobile-back--color--hover);
-		/*background: #f6f7f7;*/
 		background: var(--wp-admin--customize-themes-mobile-back--background--hover);
 		border-left-color: #2271b1;
 		box-shadow: none;
@@ -2340,8 +2258,7 @@ p.customize-section-description {
 }
 
 .wp-customizer .theme-overlay .theme-backdrop {
-	/*background: rgba(240, 240, 241, 0.75);*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-theme-backdrop--background);
 	position: fixed;
 	z-index: 110;
 }
@@ -2366,8 +2283,7 @@ p.customize-section-description {
 .wp-customizer .theme-overlay .theme-actions {
 	text-align: right; /* Because there're only one or two actions, match the UI pattern of media modals and right-align the action. */
 	padding: 10px 25px;
-	/*background: #f0f0f1;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-theme-actions--background);
 	border-top: 1px solid #dcdcde;
 }
 
@@ -2387,13 +2303,11 @@ p.customize-section-description {
 }
 
 .wp-customizer .theme-header {
-	/*background: #f0f0f1;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-theme-header--background);
 }
 
 .wp-customizer .theme-overlay .theme-header button,
 .wp-customizer .theme-overlay .theme-header .close:before {
-	/*color: #3c434a;*/
 	color: var(--wp-admin--customize-theme-header-button--color);
 }
 
@@ -2403,16 +2317,13 @@ p.customize-section-description {
 .wp-customizer .theme-overlay .theme-header .right:hover,
 .wp-customizer .theme-overlay .theme-header .left:focus,
 .wp-customizer .theme-overlay .theme-header .left:hover {
-	/*background: #fff;*/
-	background: var(--wp-admin--customize-theme-header-close--background);
+	background: var(--wp-admin--customize-theme-header-close--background--focus);
 	border-bottom: 4px solid #2271b1;
-	/*color: #2271b1;*/
 	color: var(--wp-admin--customize-theme-header-close--color--focus);
 }
 
 .wp-customizer .theme-overlay .theme-header .close:focus:before,
 .wp-customizer .theme-overlay .theme-header .close:hover:before {
-	/*color: #2271b1;*/
 	color: var(--wp-admin--customize-theme-header-close--color--focus--before);
 }
 
@@ -2420,9 +2331,7 @@ p.customize-section-description {
 .wp-customizer .theme-overlay .theme-header button.disabled:hover,
 .wp-customizer .theme-overlay .theme-header button.disabled:focus {
 	border-bottom: none;
-	/*background: transparent;*/
 	background: var(--wp-admin--customize-theme-header-button-disabled--background);
-	/*color: #c3c4c7;*/
 	color: var(--wp-admin--customize-theme-header-button-disabled--color);
 }
 
@@ -2444,8 +2353,7 @@ p.customize-section-description {
 body.cheatin {
 	font-size: medium;
 	height: auto;
-	/*background: #fff;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-cheatin--background);
 	border: 1px solid #c3c4c7;
 	margin: 50px auto 2em;
 	padding: 1em 2em;
@@ -2457,8 +2365,7 @@ body.cheatin {
 body.cheatin h1 {
 	border-bottom: 1px solid #dcdcde;
 	clear: both;
-	/*color: #50575e;*/
-	color: var(--wp-admin--cheatin-h1--color);
+	color: var(--wp-admin--customize-cheatin-h1--color);
 	font-size: 24px;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	margin: 30px 0 0 0;
@@ -2537,7 +2444,6 @@ body.cheatin p {
 	display: block;
 	width: 33px; /* was 42px for mobile */
 	height: 43px;
-	/*color: #8c8f94;*/
 	color: var(--wp-admin--customize-widget-reorder-nav--color);
 	text-indent: -9999px;
 	cursor: pointer;
@@ -2547,8 +2453,7 @@ body.cheatin p {
 .menu-item-reorder-nav button {
 	width: 30px;
 	height: 40px;
-	/*background: transparent;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-menu-item-reorder-nav--background);
 	border: none;
 	box-shadow: none;
 }
@@ -2572,10 +2477,8 @@ body.cheatin p {
 .widget-reorder-nav span:focus,
 .menu-item-reorder-nav button:hover,
 .menu-item-reorder-nav button:focus {
-	/*color: #1d2327;*/
 	color: var(--wp-admin--customize-widget-reorder-nav--color--hover);
-	/*background: #f0f0f1;*/
-	background: var(--wp-admin--customize-widget-reorder-nav--background);
+	background: var(--wp-admin--customize-widget-reorder-nav--background--hover);
 }
 
 .move-widget-down:before,
@@ -2594,9 +2497,7 @@ body.cheatin p {
 .move-down-disabled .menus-move-down,
 .move-right-disabled .menus-move-right,
 .move-left-disabled .menus-move-left {
-	/*color: #dcdcde;*/
 	color: var(--wp-admin--customize-theme-controls-move-widget-up--color);
-	/*background-color: #fff;*/
 	background-color: var(--wp-admin--customize-theme-controls-move-widget-up--background-color);
 	cursor: default;
 	pointer-events: none;
@@ -2617,11 +2518,8 @@ body.adding-widget .add-new-widget:hover,
 .adding-menu-items .add-new-menu-item:hover,
 .add-menu-toggle.open,
 .add-menu-toggle.open:hover {
-	/*background: #f0f0f1;*/
 	background: var(--wp-admin--customize-add-new-widget--background);
-	/*border-color: #8c8f94;*/
 	border-color: var(--wp-admin--customize-add-new-widget--border-color);
-	/*color: #2c3338;*/
 	color: var(--wp-admin--customize-add-new-widget--color);
 	box-shadow: inset 0 2px 5px -3px rgba(0, 0, 0, 0.5);
 }
@@ -2644,8 +2542,7 @@ body.adding-widget .add-new-widget:before,
 	width: 300px;
 	margin: 0;
 	z-index: 4;
-	/*background: #f0f0f1;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-available-widgets--background);
 	transition: left .18s;
 	border-right: 1px solid #dcdcde;
 }
@@ -2673,8 +2570,7 @@ body.adding-widget .add-new-widget:before,
 	top: 0;
 	z-index: 1;
 	width: 300px;
-	/*background: #f0f0f1;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-available-widgets-filter--background);
 }
 
 /* search field container */
@@ -2707,8 +2603,7 @@ body.adding-widget .add-new-widget:before,
 	height: 30px;
 	line-height: 2.1;
 	text-align: center;
-	/*color: #646970;*/
-	color: var(--wp-admin--customize-search-icon--color);
+	color: var(--wp-admin--customize-available-menu-items-search-icon--color);
 }
 
 #available-widgets-filter .clear-results,
@@ -2721,9 +2616,7 @@ body.adding-widget .add-new-widget:before,
 	padding: 0;
 	border: 0;
 	cursor: pointer;
-	/*background: none;*/
 	background: var(--wp-admin--customize-available-widgets-filter-clear-results--background);
-	/*color: #d63638;*/
 	color: var(--wp-admin--customize-available-widgets-filter-clear-results--color);
 	text-decoration: none;
 	outline: 0;
@@ -2753,7 +2646,6 @@ body.adding-widget .add-new-widget:before,
 #available-widgets-filter .clear-results:focus,
 #available-menu-items-search .clear-results:hover,
 #available-menu-items-search .clear-results:focus {
-	/*color: #d63638;*/
 	color: var(--wp-admin--customize-available-widgets-filter-clear-results--color--hover);
 }
 
@@ -2779,7 +2671,6 @@ body.adding-widget .add-new-widget:before,
 	top: 7px;
 	left: 26px;
 	z-index: 1;
-	/*color: #646970;*/
 	color: var(--wp-admin--customize-themes-filter-bar-search-icon--color);
 	height: 30px;
 	width: 30px;
@@ -2803,8 +2694,7 @@ body.adding-widget .add-new-widget:before,
 #available-menu-items .item-top,
 #available-menu-items .item-top:hover {
 	border: none;
-	/*background: transparent;*/
-	background: var(--wp-admin--background);
+	background: var(--wp-admin--customize-available-widgets-top--background);
 	box-shadow: none;
 }
 
@@ -2812,7 +2702,6 @@ body.adding-widget .add-new-widget:before,
 #available-menu-items .item-tpl {
 	position: relative;
 	padding: 15px 15px 15px 60px;
-	/*background: #fff;*/
 	background: var(--wp-admin--customize-available-widgets-template--background);
 	border-bottom: 1px solid #dcdcde;
 	border-left: 4px solid #fff;
@@ -2933,12 +2822,10 @@ body.adding-widget .add-new-widget:before,
 		padding: 0 12px 4px;
 		margin: 0;
 		height: 45px;
-		/*background: #f0f0f1;*/
 		background: var(--wp-admin--customize-controls-preview-toggle-small-screen--background);
 		border: 0;
 		border-right: 1px solid #dcdcde;
 		border-top: 4px solid #f0f0f1;
-		/*color: #50575e;*/
 		color: var(--wp-admin--customize-controls-preview-toggle-small-screen--color);
 		cursor: pointer;
 		transition: color .1s ease-in-out, background .1s ease-in-out;
@@ -3014,7 +2901,6 @@ body.adding-widget .add-new-widget:before,
 		padding: 9px 10px 12px 14px;
 		margin: 0;
 		line-height: 24px;
-		/*color: #50575e;*/
 		color: var(--wp-admin--customize-available-widgets-section-title-small-screen--color);
 		display: block;
 		overflow: hidden;

--- a/src/wp-includes/css/custom-properties.css
+++ b/src/wp-includes/css/custom-properties.css
@@ -104,53 +104,93 @@ body {
 
 	--wp-admin--customize-add-new-widget--background: #f0f0f1;
 	--wp-admin--customize-add-new-widget--border-color: #8c8f94;
+	--wp-admin--customize-add-new-widget--box-shadow-color_inset: rgb(0, 0, 0);
 	--wp-admin--customize-add-new-widget--color: #2c3338;
 
-	--wp-admin--customize-available-widgets--background: #f0f0f1;
-	--wp-admin--customize-available-widgets-filter--background: #f0f0f1;
+	--wp-admin--customize-accordion-section-dropdown-content--border-color: #f0f0f1;
+	--wp-admin--customize-accordion-section-installed_themes--border-top-color: #dcdcde;
+	--wp-admin--customize-accordion-section-themes-control-section--border-top-color: #dcdcde;
+
 	--wp-admin--customize-available-menu-items-search-icon--color: #646970;
+	--wp-admin--customize-available-widgets--background: #f0f0f1;
+	--wp-admin--customize-available-widgets--border-right-color: #dcdcde;
+	--wp-admin--customize-available-widgets--border-top-color: #dcdcde;
+	--wp-admin--customize-available-widgets-filter--background: #f0f0f1;
 	--wp-admin--customize-available-widgets-filter-clear-results--background: none;
+	--wp-admin--customize-available-widgets-filter-clear-results--box-shadow-color_first-outer-box--focus: #4f94d4;
+	--wp-admin--customize-available-widgets-filter-clear-results--box-shadow-color_second-outer-box--focus: rgba(79, 148, 212, 0.8);
 	--wp-admin--customize-available-widgets-filter-clear-results--color: #d63638;
 	--wp-admin--customize-available-widgets-filter-clear-results--color--hover: #d63638;
 	--wp-admin--customize-available-widgets-template--background: #fff;
+	--wp-admin--customize-available-widgets-template--border-bottom-color: #dcdcde;
+	--wp-admin--customize-available-widgets-template--border-left-color: #fff;
 	--wp-admin--customize-available-widgets-top--background: transparent;
 	--wp-admin--customize-available-widgets-section-title-small-screen--color: #50575e;
 
 	--wp-admin--customize-button-add-media--background-color: #f0f0f1;
-	--wp-admin--customize-button-add-media--color: #2c3338;
 	--wp-admin--customize-button-add-media--background-color--hover: #fff;
 	--wp-admin--customize-button-add-media--background-color--focus: #fff;
+	--wp-admin--customize-button-add-media--border-color--focus: #3582c4;
+	--wp-admin--customize-button-add-media--box-shadow-color--focus: #3582c4;
+	--wp-admin--customize-button-add-media--color: #2c3338;
 
 	--wp-admin--customize-control-changeset-inside-control-row--background-color: #fff;
+	--wp-admin--customize-control-changeset-inside-control-row--border-bottom-color: #dcdcde;
+	--wp-admin--customize-control-changeset-inside-control-row--border-top-color--first-of-type: #dcdcde;
+	--wp-admin--customize-control-changeset_preview_link-input--border-top-color: #dcdcde;
 	--wp-admin--customize-control-changeset_preview_link-input--color: #fff;
 	--wp-admin--customize-control-changeset_preview_link-disabled--color: #000;
 	--wp-admin--customize-control-changeset_scheduled_date--background: #fff;
+	--wp-admin--customize-control-changeset_scheduled_date--border-bottom-color: #dcdcde;
 
+	--wp-admin-customize-control-color-dropdown-content--border-color--hover: rgb(0, 0, 0);
+	--wp-admin--customize-control-create-page-item-input_invalid--border-color: #d63638;
+
+	--wp-admin--customize-control-header-choice--box-shadow-color_first-outer-box--focus: #4f94d4;
+	--wp-admin--customize-control-header-choice--box-shadow-color_second-outer-box--focus: rgba(79, 148, 212, 0.8);
 	--wp-admin--customize-control-header-close--background: #50575e;
 	--wp-admin--customize-control-header-close--color: #fff;
 	--wp-admin--customize-control-header-inner--color: #50575e;
+	--wp-admin--customize-control-header-view-close--outline--focus: #4f94d4;
+	--wp-admin--customize-control-header-view-selected--border-color--after: #72aee6;
+
 	--wp-admin--customize-control-panel-themes-displayed--color: #50575e;
 	--wp-admin--customize-control-panel-themes-full-container--background: #f0f0f1;
 	--wp-admin--customize-control-panel-themes-section-title--background: #fff;
 	--wp-admin--customize-control-panel-themes-section-title--background--focus: #f6f7f7;
+	--wp-admin--customize-control-panel-themes-section-title--border-bottom-color: #dcdcde;
+	--wp-admin--customize-control-panel-themes-section-title--border-left-color: #fff;
+	--wp-admin--customize-control-panel-themes-section-title--border-left-color--focus: #2271b1;
 	--wp-admin--customize-control-panel-themes-section-title--color: #50575e;
 	--wp-admin--customize-control-panel-themes-section-title--color--focus: #2271b1;
 	--wp-admin--customize-control-panel-themes-section-title-selected--color: #2271b1;
+
+	--wp-admin--customize-control-placeholder--border-color: #c3c4c7;
+
+	--wp-admin--customize-control-section-text-before--border-bottom-color: #dcdcde;
 	--wp-admin--customize-control-section-text-before--color: #50575e;
+
+	--wp-admin--customize-control-text-has-error-input--outline: #d63638;
 	--wp-admin--customize-control-theme--background: #fff;
+	--wp-admin--customize-control-theme--border-color: #dcdcde;
 	--wp-admin--customize-control-theme-name--background: #fff;
 
 	--wp-admin--customize-controls-accordian-section-title--background: #fff;
 	--wp-admin--customize-controls-accordion-section-title--background--hover: #fff;
+	--wp-admin--customize-controls-accordion-section-title--border-left-color--hover: #fff;
 	--wp-admin--customize-controls-accordion-section-title--color: #50575e;
 	--wp-admin--customize-controls-accordion-section-title--color--after: #2c3338;
 	--wp-admin--customize-controls-accordion-section-title--color--hover: #50575e;
 
 	--wp-admin--customize-controls-close--background: #f0f0f1;
 	--wp-admin--customize-controls-close--background--focus: #fff;
+	--wp-admin--customize-controls-close--border-top-color: #f0f0f1;
+	--wp-admin--customize-controls-close--border-top-color--focus: #2271b1;
+	--wp-admin--customize-controls-close--border-right-color: #dcdcde;
 	--wp-admin--customize-controls-close--color: #3c434a;
 	--wp-admin--customize-controls-close--color--focus: #2271b1;
 
+	--wp-admin--customize-controls-control-section-accordion-title--border-left-color: #2271b1;
 	--wp-admin--customize-controls-control-section-title--background: #f6f7f7;
 	--wp-admin--customize-controls-control-section-title--color: #2271b1;
 
@@ -158,22 +198,38 @@ body {
 	--wp-admin--customize-controls-customize-help-toggle--color: #50575e;
 	--wp-admin--customize-controls-customize-info-open-help-toggle--color: #2271b1;
 	--wp-admin--customize-controls-customize-panel-description--background: #fff;
+	--wp-admin--customize-controls-customize-panel-description--border-top-color: #dcdcde;
 	--wp-admin--customize-controls-customize-panel-description--color: #50575e;
 
 	--wp-admin--customize-controls-date-input--border-color--invalid: #d63638;
 	--wp-admin--customize-controls-description--color: #50575e;
 
+	--wp-admin--customize-controls-info--border-bottom-color: #dcdcde;
+	--wp-admin--customize-controls-info-is-in-view--box-shadow-color: rgb(0, 0, 0);
+
 	--wp-admin--customize-controls-full-overlay-sidebar-content--background: #f0f0f1;
 
+	--wp-admin-customize-controls-notification-area--border-bottom-color: #dcdcde;
+	--wp-admin-customize-controls-notification-container--border-top-color: #dcdcde;
+
+	--wp-admin--customize-controls-panel-description-open--border-top-color: none;
 	--wp-admin--customize-controls-preview-toggle-small-screen--background: #f0f0f1;
+	--wp-admin--customize-controls-preview-toggle-small-screen--border-right-color: #dcdcde;
+	--wp-admin--customize-controls-preview-toggle-small-screen--border-top-color: #f0f0f1;
 	--wp-admin--customize-controls-preview-toggle-small-screen--color: #50575e;
+
+	--wp-admin--customize-controls-widget-form-has-error--box-shadow-color_inset: #d63638;
 
 	--wp-admin--customize-copy-preview-link--background--before: #fff;
 
 	--wp-admin--customize-cheatin--background: #fff;
+	--wp-admin--customize-cheatin--border-color: #c3c4c7;
+	--wp-admin--customize-cheatin--box-shadow-color: rgb(0, 0, 0);
+	--wp-admin--customize-cheatin-h1--border-bottom-color: #dcdcde;
 	--wp-admin--customize-cheatin-h1--color: #50575e;
 
 	--wp-admin--customize-dropdown-content--background-color: #50575e;
+	--wp-admin--customize-dropdown-content--border-color: rgb(0, 0, 0);
 
 	--wp-admin--customize-dropdown-arrow--background: #f0f0f1;
 	--wp-admin--customize-dropdown-arrow--color--after: #2c3338;
@@ -182,10 +238,14 @@ body {
 	--wp-admin--customize-dropdown-status--color: #2c3338;
 
 	--wp-admin--customize-filter-drawer--background: #f0f0f1;
+	--wp-admin--customize-filter-drawer--border-bottom-color: #dcdcde;
 
 	--wp-admin--customize-full-overlay-header--background-color: #f0f0f1;
 	--wp-admin--customize-full-overlay-in-themes-panel--background: #f0f0f1;
 	--wp-admin--customize-full-overlay-sidebar--background: #f0f0f1;
+	--wp-admin--customize-full-overlay-sidebar--border-right-color: #dcdcde;
+
+	--wp-admin-customize-header-actions--border-bottom-color: #dcdcde;
 
 	--wp-admin--customize-js-control-section-title--background: #f6f7f7;
 
@@ -193,33 +253,55 @@ body {
 
 	--wp-admin--customize-notification-changeset-locked--background-color: rgba(0, 0, 0, 0.7);
 	--wp-admin--customize-notification-changeset-locked-message--background: #fff;
+	--wp-admin--customize-notification-changeset-locked-message--box-shadow-color: rgb(0, 0, 0);
 	--wp-admin--customize-notification-message--color: #1d2327;
 
 	--wp-admin--customize-panel-back--background: #fff;
 	--wp-admin--customize-panel-back--background--hover: #f6f7f7;
+	--wp-admin--customize-panel-back--border-right-color: #dcdcde;
+	--wp-admin--customize-panel-back--border-left-color: #fff;
+	--wp-admin--customize-panel-back--border-left-color--hover: #2271b1;
+
 	--wp-admin--customize-panel-back--color--hover: #2271b1;
 
 	--wp-admin--customize-preview-header-themes-filter-bar--background: #f0f0f1;
+	--wp-admin--customize-preview-header-themes-filter-bar--border-bottom-color: #dcdcde;
 
+	--wp-admin--customize-save-button--box-shadow-color_bottom--focus: #2271b1;
+	--wp-admin--customize-save-button--box-shadow-color_top-and-sides--focus: #72aee6;
 	--wp-admin--customize-section-title--background: #fff;
+	--wp-admin--customize-section-title--border-bottom-color: #dcdcde;
 	--wp-admin--customize-section-title-h3--color: #50575e;
 	--wp-admin--customize-section-content-new-content-item--background: #f0f0f1;
 
 	--wp-admin--customize-sidebar-outer-content--background: #f0f0f1;
+	--wp-admin--customize-sidebar-outer-content--border-right-color: #dcdcde;
+	--wp-admin--customize-sidebar-outer-content--border-left-color: #dcdcde;
 
 	--wp-admin--customize-theme-actions--background: #f0f0f1;
+	--wp-admin--customize-theme-actions--border-top-color: #dcdcde;
+	--wp-admin--customize-theme-actions--box-shadow-color: rgb(0, 0, 0);
 
 	--wp-admin--customize-theme-backdrop--background: rgba(240, 240, 241, 0.75);
 
 	--wp-admin--customize-theme-controls-accordion-section-content--background: transparent;
 	--wp-admin--customize-theme-controls-accordion-section-content--color: #50575e;
 	--wp-admin--customize-theme-controls-accordion-section-title--background-color: #fff;
+	--wp-admin--customize-theme-controls-accordion-section-title--border-bottom-color: #dcdcde;
+	--wp-admin--customize-theme-controls-accordion-section-title--border-left-color: #fff;
 	--wp-admin--customize-theme-controls-accordion-section-title--color: #50575e;
 	--wp-admin--customize-theme-controls-accordion-section-title--color--after: #a7aaad;
 	--wp-admin--customize-theme-controls-control-panel-themes-title--background--hover: #fff;
+	--wp-admin--customize-theme-controls-control-panel-themes-title--border-top-color--hover: #dcdcde;
+	--wp-admin--customize-theme-controls-control-panel-themes-title--border-bottom-color--hover: #dcdcde;
 	--wp-admin--customize-theme-controls-control-panel-themes-title--color--hover: #50575e;
 	--wp-admin--customize-theme-controls-move-widget-up--background-color: #fff;
 	--wp-admin--customize-theme-controls-move-widget-up--color: #dcdcde;
+	--wp-admin--customize-theme-controls-section--border-bottom-color--last-of-type-open: #dcdcde;
+	--wp-admin--customize-theme-controls-section--border-top-color--nth-child-2: #dcdcde;
+	--wp-admin--customize-theme-controls-section-nav_menu--border-top-color: none;
+	--wp-admin--customize-theme-controls-section-open--border-bottom-color: #f0f0f1;
+	--wp-admin--customize-theme-controls-section-title--border-bottom-color--first-child: #dcdcde;
 	--wp-admin--customize-theme-controls-section-title--color--after: #2271b1;
 
 	--wp-admin--customize-theme-header--background: #f0f0f1;
@@ -227,19 +309,26 @@ body {
 	--wp-admin--customize-theme-header-button-disabled--background: transparent;
 	--wp-admin--customize-theme-header-button-disabled--color: #c3c4c7;
 	--wp-admin--customize-theme-header-close--background--focus: #fff;
+	--wp-admin--customize-theme-header-close--border-bottom-color--focus: #2271b1;
 	--wp-admin--customize-theme-header-close--color--focus: #2271b1;
 	--wp-admin--customize-theme-header-close--color--focus--before: #2271b1;
 
 	--wp-admin--customize-themes-feature-filter-toggle-open--background: #f0f0f1;
 	--wp-admin--customize-themes-feature-filter-toggle-open--border-color: #8c8f94;
+	--wp-admin--customize-themes-feature-filter-toggle-open--box-shadow-color_inset: rgb(0, 0, 0);
 	--wp-admin--customize-themes-filter-bar-search-icon--color: #646970;
 
 	--wp-admin--customize-themes-mobile-back--background: #f0f0f1;
 	--wp-admin--customize-themes-mobile-back--background--hover: #f6f7f7;
+	--wp-admin--customize-themes-mobile-back--border-bottom-color: #dcdcde;
+	--wp-admin--customize-themes-mobile-back--border-left-color: transparent;
+	--wp-admin--customize-themes-mobile-back--border-left-color--hover: #2271b1;
+	--wp-admin--customize-themes-mobile-back--border-right-color--before: #dcdcde;
 	--wp-admin--customize-themes-mobile-back--color: #3c434a;
 	--wp-admin--customize-themes-mobile-back--color--hover: #2271b1;
 
 	--wp-admin--customize-themes-section-title-not-selected--background--after: #fff;
+	--wp-admin--customize-themes-section-title-not-selected--border-color--after: #c3c4c7;
 	--wp-admin--customize-themes-section-title-selected--background--after: #2271b1;
 	--wp-admin--customize-themes-section-title-selected--color--after: #fff;
 

--- a/src/wp-includes/css/custom-properties.css
+++ b/src/wp-includes/css/custom-properties.css
@@ -141,24 +141,24 @@ body {
 	--wp-admin--customize-control-theme-name--background: #fff;
 
 	--wp-admin--customize-controls-accordian-section-title--background: #fff;
+	--wp-admin--customize-controls-accordion-section-title--background--hover: #fff;
 	--wp-admin--customize-controls-accordion-section-title--color: #50575e;
 	--wp-admin--customize-controls-accordion-section-title--color--after: #2c3338;
-	--wp-admin--customize-controls-accordion-section-title--background--hover: #fff;
 	--wp-admin--customize-controls-accordion-section-title--color--hover: #50575e;
 
 	--wp-admin--customize-controls-close--background: #f0f0f1;
-	--wp-admin--customize-controls-close--color: #3c434a;
 	--wp-admin--customize-controls-close--background--focus: #fff;
+	--wp-admin--customize-controls-close--color: #3c434a;
 	--wp-admin--customize-controls-close--color--focus: #2271b1;
 
-	--wp-admin--customize-controls-control-section-title--color: #2271b1;
 	--wp-admin--customize-controls-control-section-title--background: #f6f7f7;
+	--wp-admin--customize-controls-control-section-title--color: #2271b1;
 
 	--wp-admin--customize-controls-customize-help-toggle--background: transparent;
 	--wp-admin--customize-controls-customize-help-toggle--color: #50575e;
 	--wp-admin--customize-controls-customize-info-open-help-toggle--color: #2271b1;
-	--wp-admin--customize-controls-customize-panel-description--color: #50575e;
 	--wp-admin--customize-controls-customize-panel-description--background: #fff;
+	--wp-admin--customize-controls-customize-panel-description--color: #50575e;
 
 	--wp-admin--customize-controls-date-input--border-color--invalid: #d63638;
 	--wp-admin--customize-controls-description--color: #50575e;
@@ -196,8 +196,8 @@ body {
 	--wp-admin--customize-notification-message--color: #1d2327;
 
 	--wp-admin--customize-panel-back--background: #fff;
-	--wp-admin--customize-panel-back--color--hover: #2271b1;
 	--wp-admin--customize-panel-back--background--hover: #f6f7f7;
+	--wp-admin--customize-panel-back--color--hover: #2271b1;
 
 	--wp-admin--customize-preview-header-themes-filter-bar--background: #f0f0f1;
 
@@ -211,15 +211,15 @@ body {
 
 	--wp-admin--customize-theme-backdrop--background: rgba(240, 240, 241, 0.75);
 
-	--wp-admin--customize-theme-controls-accordion-section-content--color: #50575e;
 	--wp-admin--customize-theme-controls-accordion-section-content--background: transparent;
-	--wp-admin--customize-theme-controls-accordion-section-title--color: #50575e;
+	--wp-admin--customize-theme-controls-accordion-section-content--color: #50575e;
 	--wp-admin--customize-theme-controls-accordion-section-title--background-color: #fff;
+	--wp-admin--customize-theme-controls-accordion-section-title--color: #50575e;
 	--wp-admin--customize-theme-controls-accordion-section-title--color--after: #a7aaad;
 	--wp-admin--customize-theme-controls-control-panel-themes-title--background--hover: #fff;
 	--wp-admin--customize-theme-controls-control-panel-themes-title--color--hover: #50575e;
-	--wp-admin--customize-theme-controls-move-widget-up--color: #dcdcde;
 	--wp-admin--customize-theme-controls-move-widget-up--background-color: #fff;
+	--wp-admin--customize-theme-controls-move-widget-up--color: #dcdcde;
 	--wp-admin--customize-theme-controls-section-title--color--after: #2271b1;
 
 	--wp-admin--customize-theme-header--background: #f0f0f1;
@@ -243,12 +243,12 @@ body {
 	--wp-admin--customize-themes-section-title-selected--background--after: #2271b1;
 	--wp-admin--customize-themes-section-title-selected--color--after: #fff;
 
-	--wp-admin--customize-uploaded-button--background: none;
-	--wp-admin--customize-uploaded-button--color: inherit;
+	--wp-admin--customize-uploaded-button--background--not-random: none;
+	--wp-admin--customize-uploaded-button--color--not-random: inherit;
 
+	--wp-admin--customize-widget-reorder-nav--background--hover: #f0f0f1;
 	--wp-admin--customize-widget-reorder-nav--color: #8c8f94;
 	--wp-admin--customize-widget-reorder-nav--color--hover: #1d2327;
-	--wp-admin--customize-widget-reorder-nav--background--hover: #f0f0f1;
 }
 
 body.admin-color-ectoplasm {

--- a/src/wp-includes/css/custom-properties.css
+++ b/src/wp-includes/css/custom-properties.css
@@ -101,6 +101,154 @@ body {
 	--wp-admin--plugin-modal-banner-title--background: rgba(29, 35, 39, 0.9);
 
 	--wp-admin--site-icon--background-color: #000;
+
+	--wp-admin--customize-add-new-widget--background: #f0f0f1;
+	--wp-admin--customize-add-new-widget--border-color: #8c8f94;
+	--wp-admin--customize-add-new-widget--color: #2c3338;
+
+	--wp-admin--customize-available-widgets--background: #f0f0f1;
+	--wp-admin--customize-available-widgets-filter--background: #f0f0f1;
+	--wp-admin--customize-available-menu-items-search-icon--color: #646970;
+	--wp-admin--customize-available-widgets-filter-clear-results--background: none;
+	--wp-admin--customize-available-widgets-filter-clear-results--color: #d63638;
+	--wp-admin--customize-available-widgets-filter-clear-results--color--hover: #d63638;
+	--wp-admin--customize-available-widgets-template--background: #fff;
+	--wp-admin--customize-available-widgets-top--background: transparent;
+	--wp-admin--customize-available-widgets-section-title-small-screen--color: #50575e;
+
+	--wp-admin--customize-button-add-media--background-color: #f0f0f1;
+	--wp-admin--customize-button-add-media--color: #2c3338;
+	--wp-admin--customize-button-add-media--background-color--hover: #fff;
+	--wp-admin--customize-button-add-media--background-color--focus: #fff;
+
+	--wp-admin--customize-control-changeset-inside-control-row--background-color: #fff;
+	--wp-admin--customize-control-changeset_preview_link-input--color: #fff;
+	--wp-admin--customize-control-changeset_preview_link-disabled--color: #000;
+	--wp-admin--customize-control-changeset_scheduled_date--background: #fff;
+
+	--wp-admin--customize-control-header-close--background: #50575e;
+	--wp-admin--customize-control-header-close--color: #fff;
+	--wp-admin--customize-control-header-inner--color: #50575e;
+	--wp-admin--customize-control-panel-themes-displayed--color: #50575e;
+	--wp-admin--customize-control-panel-themes-full-container--background: #f0f0f1;
+	--wp-admin--customize-control-panel-themes-section-title--background: #fff;
+	--wp-admin--customize-control-panel-themes-section-title--background--focus: #f6f7f7;
+	--wp-admin--customize-control-panel-themes-section-title--color: #50575e;
+	--wp-admin--customize-control-panel-themes-section-title--color--focus: #2271b1;
+	--wp-admin--customize-control-panel-themes-section-title-selected--color: #2271b1;
+	--wp-admin--customize-control-section-text-before--color: #50575e;
+	--wp-admin--customize-control-theme--background: #fff;
+	--wp-admin--customize-control-theme-name--background: #fff;
+
+	--wp-admin--customize-controls-accordian-section-title--background: #fff;
+	--wp-admin--customize-controls-accordion-section-title--color: #50575e;
+	--wp-admin--customize-controls-accordion-section-title--color--after: #2c3338;
+	--wp-admin--customize-controls-accordion-section-title--background--hover: #fff;
+	--wp-admin--customize-controls-accordion-section-title--color--hover: #50575e;
+
+	--wp-admin--customize-controls-close--background: #f0f0f1;
+	--wp-admin--customize-controls-close--color: #3c434a;
+	--wp-admin--customize-controls-close--background--focus: #fff;
+	--wp-admin--customize-controls-close--color--focus: #2271b1;
+
+	--wp-admin--customize-controls-control-section-title--color: #2271b1;
+	--wp-admin--customize-controls-control-section-title--background: #f6f7f7;
+
+	--wp-admin--customize-controls-customize-help-toggle--background: transparent;
+	--wp-admin--customize-controls-customize-help-toggle--color: #50575e;
+	--wp-admin--customize-controls-customize-info-open-help-toggle--color: #2271b1;
+	--wp-admin--customize-controls-customize-panel-description--color: #50575e;
+	--wp-admin--customize-controls-customize-panel-description--background: #fff;
+
+	--wp-admin--customize-controls-date-input--border-color--invalid: #d63638;
+	--wp-admin--customize-controls-description--color: #50575e;
+
+	--wp-admin--customize-controls-full-overlay-sidebar-content--background: #f0f0f1;
+
+	--wp-admin--customize-controls-preview-toggle-small-screen--background: #f0f0f1;
+	--wp-admin--customize-controls-preview-toggle-small-screen--color: #50575e;
+
+	--wp-admin--customize-copy-preview-link--background--before: #fff;
+
+	--wp-admin--customize-cheatin--background: #fff;
+	--wp-admin--customize-cheatin-h1--color: #50575e;
+
+	--wp-admin--customize-dropdown-content--background-color: #50575e;
+
+	--wp-admin--customize-dropdown-arrow--background: #f0f0f1;
+	--wp-admin--customize-dropdown-arrow--color--after: #2c3338;
+
+	--wp-admin--customize-dropdown-status--background: #f0f0f1;
+	--wp-admin--customize-dropdown-status--color: #2c3338;
+
+	--wp-admin--customize-filter-drawer--background: #f0f0f1;
+
+	--wp-admin--customize-full-overlay-header--background-color: #f0f0f1;
+	--wp-admin--customize-full-overlay-in-themes-panel--background: #f0f0f1;
+	--wp-admin--customize-full-overlay-sidebar--background: #f0f0f1;
+
+	--wp-admin--customize-js-control-section-title--background: #f6f7f7;
+
+	--wp-admin--customize-menu-item-reorder-nav--background: transparent;
+
+	--wp-admin--customize-notification-changeset-locked--background-color: rgba(0, 0, 0, 0.7);
+	--wp-admin--customize-notification-changeset-locked-message--background: #fff;
+	--wp-admin--customize-notification-message--color: #1d2327;
+
+	--wp-admin--customize-panel-back--background: #fff;
+	--wp-admin--customize-panel-back--color--hover: #2271b1;
+	--wp-admin--customize-panel-back--background--hover: #f6f7f7;
+
+	--wp-admin--customize-preview-header-themes-filter-bar--background: #f0f0f1;
+
+	--wp-admin--customize-section-title--background: #fff;
+	--wp-admin--customize-section-title-h3--color: #50575e;
+	--wp-admin--customize-section-content-new-content-item--background: #f0f0f1;
+
+	--wp-admin--customize-sidebar-outer-content--background: #f0f0f1;
+
+	--wp-admin--customize-theme-actions--background: #f0f0f1;
+
+	--wp-admin--customize-theme-backdrop--background: rgba(240, 240, 241, 0.75);
+
+	--wp-admin--customize-theme-controls-accordion-section-content--color: #50575e;
+	--wp-admin--customize-theme-controls-accordion-section-content--background: transparent;
+	--wp-admin--customize-theme-controls-accordion-section-title--color: #50575e;
+	--wp-admin--customize-theme-controls-accordion-section-title--background-color: #fff;
+	--wp-admin--customize-theme-controls-accordion-section-title--color--after: #a7aaad;
+	--wp-admin--customize-theme-controls-control-panel-themes-title--background--hover: #fff;
+	--wp-admin--customize-theme-controls-control-panel-themes-title--color--hover: #50575e;
+	--wp-admin--customize-theme-controls-move-widget-up--color: #dcdcde;
+	--wp-admin--customize-theme-controls-move-widget-up--background-color: #fff;
+	--wp-admin--customize-theme-controls-section-title--color--after: #2271b1;
+
+	--wp-admin--customize-theme-header--background: #f0f0f1;
+	--wp-admin--customize-theme-header-button--color: #3c434a;
+	--wp-admin--customize-theme-header-button-disabled--background: transparent;
+	--wp-admin--customize-theme-header-button-disabled--color: #c3c4c7;
+	--wp-admin--customize-theme-header-close--background--focus: #fff;
+	--wp-admin--customize-theme-header-close--color--focus: #2271b1;
+	--wp-admin--customize-theme-header-close--color--focus--before: #2271b1;
+
+	--wp-admin--customize-themes-feature-filter-toggle-open--background: #f0f0f1;
+	--wp-admin--customize-themes-feature-filter-toggle-open--border-color: #8c8f94;
+	--wp-admin--customize-themes-filter-bar-search-icon--color: #646970;
+
+	--wp-admin--customize-themes-mobile-back--background: #f0f0f1;
+	--wp-admin--customize-themes-mobile-back--background--hover: #f6f7f7;
+	--wp-admin--customize-themes-mobile-back--color: #3c434a;
+	--wp-admin--customize-themes-mobile-back--color--hover: #2271b1;
+
+	--wp-admin--customize-themes-section-title-not-selected--background--after: #fff;
+	--wp-admin--customize-themes-section-title-selected--background--after: #2271b1;
+	--wp-admin--customize-themes-section-title-selected--color--after: #fff;
+
+	--wp-admin--customize-uploaded-button--background: none;
+	--wp-admin--customize-uploaded-button--color: inherit;
+
+	--wp-admin--customize-widget-reorder-nav--color: #8c8f94;
+	--wp-admin--customize-widget-reorder-nav--color--hover: #1d2327;
+	--wp-admin--customize-widget-reorder-nav--background--hover: #f0f0f1;
 }
 
 body.admin-color-ectoplasm {


### PR DESCRIPTION
The following files for WordPress Core were updated:

- `wordpress-develop/src/wp-admin/css/customize-controls.css`; and
- `wordpress-develop/src/wp-includes/css/custom-properties.css`.

The following CSS properties in `customize-controls.css` were assigned a CSS variable name:

- `background`, 
- `background-color`, 
- `border-*-color`,
- `box-shadow-color`, 
- `color`, and 
- `outline`.

The color value of each custom variable was added to `custom-properties.css`.  

Trac ticket: [#49930, "Replace wp-admin color schemes with CSS custom properties".](https://core.trac.wordpress.org/ticket/49930#no1) 
