### PR TITLE
Style Loader: Add new CSS dependency for `custom-properties` file, revert colors changes

### DIFF
--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -74,6 +74,7 @@ _wp_admin_html_begin();
 <title><?php echo esc_html( $admin_title ); ?></title>
 <?php
 
+wp_enqueue_style( 'wp-admin' );
 wp_enqueue_style( 'colors' );
 wp_enqueue_script( 'utils' );
 wp_enqueue_script( 'svg-painter' );

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -522,6 +522,7 @@ function wp_iframe( $content_func, ...$args ) {
 	<title><?php bloginfo( 'name' ); ?> &rsaquo; <?php _e( 'Uploads' ); ?> &#8212; <?php _e( 'WordPress' ); ?></title>
 	<?php
 
+	wp_enqueue_style( 'wp-admin' );
 	wp_enqueue_style( 'colors' );
 	// Check callback name for 'media'.
 	if (

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2028,6 +2028,7 @@ function iframe_header( $title = '', $deprecated = false ) {
 	?>
 <title><?php bloginfo( 'name' ); ?> &rsaquo; <?php echo $title; ?> &#8212; <?php _e( 'WordPress' ); ?></title>
 	<?php
+	wp_enqueue_style( 'wp-admin' );
 	wp_enqueue_style( 'colors' );
 	?>
 <script type="text/javascript">

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1430,7 +1430,7 @@ function wp_default_styles( $styles ) {
 	}
 
 	// Register a stylesheet for the selected admin color scheme.
-	$styles->add( 'colors', true, array( 'wp-admin', 'buttons' ) );
+	$styles->add( 'colors', true );
 
 	$suffix = SCRIPT_DEBUG ? '' : '.min';
 
@@ -1452,7 +1452,7 @@ function wp_default_styles( $styles ) {
 	$styles->add( 'code-editor', "/wp-admin/css/code-editor$suffix.css", array( 'wp-codemirror' ) );
 	$styles->add( 'site-health', "/wp-admin/css/site-health$suffix.css" );
 
-	$styles->add( 'wp-admin', false, array( 'dashicons', 'common', 'forms', 'admin-menu', 'dashboard', 'list-tables', 'edit', 'revisions', 'media', 'themes', 'about', 'nav-menus', 'widgets', 'site-icon', 'l10n' ) );
+	$styles->add( 'wp-admin', false, array( 'dashicons', 'buttons', 'custom-properties', 'common', 'forms', 'admin-menu', 'dashboard', 'list-tables', 'edit', 'revisions', 'media', 'themes', 'about', 'nav-menus', 'widgets', 'site-icon', 'l10n' ) );
 
 	$styles->add( 'login', "/wp-admin/css/login$suffix.css", array( 'dashicons', 'buttons', 'forms', 'l10n', 'custom-properties' ) );
 	$styles->add( 'install', "/wp-admin/css/install$suffix.css", array( 'dashicons', 'buttons', 'forms', 'l10n', 'custom-properties' ) );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1430,7 +1430,7 @@ function wp_default_styles( $styles ) {
 	}
 
 	// Register a stylesheet for the selected admin color scheme.
-	$styles->add( 'colors', '/wp-includes/css/custom-properties.css', array( 'wp-admin', 'buttons' ) );
+	$styles->add( 'colors', true, array( 'wp-admin', 'buttons' ) );
 
 	$suffix = SCRIPT_DEBUG ? '' : '.min';
 
@@ -1865,8 +1865,33 @@ function wp_localize_community_events() {
  * @return string|false URL path to CSS stylesheet for Administration Screens.
  */
 function wp_style_loader_src( $src, $handle ) {
+	global $_wp_admin_css_colors;
+
 	if ( wp_installing() ) {
 		return preg_replace( '#^wp-admin/#', './', $src );
+	}
+
+	if ( 'colors' === $handle ) {
+		$color = get_user_option( 'admin_color' );
+
+		if ( empty( $color ) || ! isset( $_wp_admin_css_colors[ $color ] ) ) {
+			$color = 'fresh';
+		}
+
+		$color = $_wp_admin_css_colors[ $color ];
+		$url   = $color->url;
+
+		if ( ! $url ) {
+			return false;
+		}
+
+		$parsed = parse_url( $src );
+		if ( isset( $parsed['query'] ) && $parsed['query'] ) {
+			wp_parse_str( $parsed['query'], $qv );
+			$url = add_query_arg( $qv, $url );
+		}
+
+		return $url;
 	}
 
 	return $src;

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1454,8 +1454,8 @@ function wp_default_styles( $styles ) {
 
 	$styles->add( 'wp-admin', false, array( 'dashicons', 'common', 'forms', 'admin-menu', 'dashboard', 'list-tables', 'edit', 'revisions', 'media', 'themes', 'about', 'nav-menus', 'widgets', 'site-icon', 'l10n' ) );
 
-	$styles->add( 'login', "/wp-admin/css/login$suffix.css", array( 'dashicons', 'buttons', 'forms', 'l10n', 'colors' ) );
-	$styles->add( 'install', "/wp-admin/css/install$suffix.css", array( 'dashicons', 'buttons', 'forms', 'l10n', 'colors' ) );
+	$styles->add( 'login', "/wp-admin/css/login$suffix.css", array( 'dashicons', 'buttons', 'forms', 'l10n', 'custom-properties' ) );
+	$styles->add( 'install', "/wp-admin/css/install$suffix.css", array( 'dashicons', 'buttons', 'forms', 'l10n', 'custom-properties' ) );
 	$styles->add( 'wp-color-picker', "/wp-admin/css/color-picker$suffix.css" );
 	$styles->add( 'customize-controls', "/wp-admin/css/customize-controls$suffix.css", array( 'wp-admin', 'colors', 'imgareaselect' ) );
 	$styles->add( 'customize-widgets', "/wp-admin/css/customize-widgets$suffix.css", array( 'wp-admin', 'colors' ) );
@@ -1463,6 +1463,7 @@ function wp_default_styles( $styles ) {
 
 	// Common dependencies.
 	$styles->add( 'buttons', "/wp-includes/css/buttons$suffix.css" );
+	$styles->add( 'custom-properties', "/wp-includes/css/custom-properties$suffix.css" );
 	$styles->add( 'dashicons', "/wp-includes/css/dashicons$suffix.css" );
 
 	// Includes CSS.


### PR DESCRIPTION
This is an alternate approach to #7 - Adding new CSS dependency for the `custom-properties` file. This is added as a dependency to the main "entrypoint" stylesheets: `wp-admin`, `login`, `install`. Might need to be added to others, too (checking where `dashicons` is added could be a starting point).

This also brings back the current handling of the `colors` stylesheet (so legacy color schemes work correctly again). We'll want to keep those as-is for back-compat anyway. Having dependencies of `colors` (`wp-admin` and `buttons`) was a workaround to ensure that the colors stylesheet is always output last, but because of that, `wp-admin` isn't directly enqueued anywhere, instead it's always `colors`. This has been changed by removing the dependencies of `colors`, and explicitly enqueuing both `wp-admin` and `colors` where necessary. IMO, this makes the behavior more clear.

To test:

- Spot check various pages to make sure the custom properties are loading
- Try with a different admin scheme, the scheme's color rules should override the base CSS, meaning the legacy color schemes should work as they do in 5.8.