### PR TITLE
Update common.css

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1001,7 +1001,6 @@ th.action-links {
 	box-shadow: 0 1px 1px rgb(var(--wp-admin--shadow) / 0.04);
 	border: 1px solid var(--wp-admin--surface--border-step-1);
 	background: var(--wp-admin--surface--background);
-	color: ;
 	font-size: 13px;
 }
 
@@ -2417,7 +2416,6 @@ body.iframe {
 
 .importer-action {
 	line-height: 1.55; /* Same as with .updating-message */
-	color: ;
 	margin-bottom: 1em;
 }
 


### PR DESCRIPTION
After importing wp-admin/css/common.css I can't compile the style because there are 2 issues (value is missing for `color: ;`)
https://github.com/erikyo/wp-notify/runs/5528212841?check_suite_focus=true

I can make it work (here)[https://erikyo.github.io/wp-notify/] using erikyo:patch-1, but it would be nice to use the in-development style for this kind of thing. In addition it might also be convenient for you for testing the custom props style